### PR TITLE
Update SBT, Scala and dependencies. Refactor code for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import xerial.sbt.Sonatype._
 
 
 lazy val commonSettings: Seq[Setting[_]]  = Seq(
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.13.0",
   scalacOptions ++= Seq("-feature", "-unchecked"),
   organization := "net.team2xh",
   publishTo := sonatypePublishTo.value,
@@ -28,7 +28,7 @@ lazy val scurses = (project in file("scurses"))
   .settings(
     name := "scurses",
     version := "1.0.1",
-    libraryDependencies += "com.lihaoyi" %% "fastparse" % "2.1.0",
+    libraryDependencies += "com.lihaoyi" %% "fastparse" % "2.1.3",
     mainClass in (Compile, run) := Some("net.team2xh.scurses.examples.GameOfLife")
   )
 

--- a/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
@@ -51,7 +51,7 @@ case class FramePanel(parent: Component)
 
   var currentTab = 0
   var tabs =
-    mutable.MutableList[(ListBuffer[Widget], Int, ListBuffer[Int])]((ListBuffer[Widget](), 0, ListBuffer[Int]()))
+    mutable.ArrayDeque[(ListBuffer[Widget], Int, ListBuffer[Int])]((ListBuffer[Widget](), 0, ListBuffer[Int]()))
 
   def widgets = tabs(currentTab)._1
   def widgetFocus = tabs(currentTab)._2

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
@@ -12,7 +12,7 @@ case class RichLabel(parent: FramePanel, text: Varying[RichText])
   var lines = Seq[RichText]()
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
-    lines = TextWrap.wrapText(text.value, innerWidth - 1)
+    lines = TextWrap.wrapText(text.value, innerWidth - 1).toSeq
     for ((line, i) <- lines.zipWithIndex) {
       screen.putRichText(1, i, lines(i), theme.foreground, theme.background)
     }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
@@ -42,7 +42,7 @@ case class ScatterPlot[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T
     }
 
     // Prepare values (we use half vertical resolution)
-    val points = mutable.MutableList.fill[Int](graphWidth+1, graphHeight+1)(0)
+    val points = mutable.ArrayDeque.fill[Int](graphWidth+1, graphHeight+1)(0)
     val charHeight = (maxY - minY).toDouble / graphHeight
     for (value <- values.value) {
       val nx = math.round((graphWidth * (value._1.toDouble - minX)) / (maxX - minX)).toInt

--- a/onions/src/main/scala/net/team2xh/onions/utils/TextWrap.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/TextWrap.scala
@@ -13,17 +13,17 @@ object TextWrap {
   val CENTER      = 2
   val JUSTIFY     = 3
 
-  def wrapText(richText: RichText, width: Int): Seq[RichText] = {
+  def wrapText(richText: RichText, width: Int): mutable.Seq[RichText] = {
     wrapText(richText, width, ALIGN_LEFT)
   }
 
-  def wrapText(richText: RichText, width: Int, alignment: Int): Seq[RichText] = {
+  def wrapText(richText: RichText, width: Int, alignment: Int): mutable.Seq[RichText] = {
     val instructions = richText.instructions.iterator
     var spaceLeft = width
 
     var activeAttributes = mutable.Map[Attribute, Instruction]()
-    var lines = mutable.MutableList[(List[Instruction], Int)]()
-    var line = mutable.MutableList[Instruction]()
+    var lines = mutable.ArrayDeque[(List[Instruction], Int)]()
+    var line = mutable.ArrayDeque[Instruction]()
     var chunk = ""
 
     while (instructions.hasNext) {
@@ -51,7 +51,7 @@ object TextWrap {
             if ((word.length + 1) > spaceLeft) {
               line += Text(chunk)
               lines += ((line.toList, spaceLeft))
-              line = mutable.MutableList[Instruction]()
+              line = mutable.ArrayDeque[Instruction]()
               activeAttributes.foreach { case (k, v) => line += v }
               chunk = word + " "
               spaceLeft = width - (word.length + 1)
@@ -72,15 +72,15 @@ object TextWrap {
     val tokenizer = new StringTokenizer(text)
     var spaceLeft = width
 
-    val lines = mutable.MutableList[(List[String], Int)]()
-    var line = mutable.MutableList[String]()
+    val lines = mutable.ArrayDeque[(List[String], Int)]()
+    var line = mutable.ArrayDeque[String]()
 
     while (tokenizer.hasMoreTokens) {
       val word = tokenizer.nextToken
 
       if ((word.length + 1) > spaceLeft) {
         lines += ((line.toList, spaceLeft))
-        line = mutable.MutableList[String](word)
+        line = mutable.ArrayDeque[String](word)
         spaceLeft = width - (word.length + 1)
       } else {
         line += word
@@ -89,13 +89,13 @@ object TextWrap {
     }
     lines += ((line.toList, spaceLeft))
     alignment match {
-      case ALIGN_LEFT => lines.map(_._1.mkString(" "))
-      case ALIGN_RIGHT => lines.map { case (l, s) => " " * s + l.mkString(" ") }
+      case ALIGN_LEFT => lines.map(_._1.mkString(" ")).toSeq
+      case ALIGN_RIGHT => lines.map { case (l, s) => " " * s + l.mkString(" ") }.toSeq
       case CENTER => lines.map { case (l, s) =>
         val s1 = s / 2
         val s2 = s - s1
         " " * s1 + l.mkString(" ") + " " * s2
-      }
+      }.toSeq
       case JUSTIFY => lines.zipWithIndex.map { case ((l, s), i) =>
         if (l.length == 1) {
           l.head
@@ -113,7 +113,7 @@ object TextWrap {
             } else word + " " * (spaceWidth + 1)
           }.mkString
         }
-      }
+      }.toSeq
     }
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
 logLevel := Level.Warn

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ libraryDependencies += "net.team2xh" %% "scurses" % "<version in the badge>"
 - Hello World:
 
 ```R
-$ sbt "scurses/run-main net.team2xh.scurses.examples.HelloWorld"
+$ sbt "scurses/runMain net.team2xh.scurses.examples.HelloWorld"
 ```
   
 - Game of life:
@@ -134,7 +134,7 @@ $ sbt scurses/run
 - Stress test:
 
 ```R
-$ sbt "scurses/run-main net.team2xh.scurses.examples.StressTest"
+$ sbt "scurses/runMain net.team2xh.scurses.examples.StressTest"
 ```
 
 ## How to use

--- a/scurses/src/main/scala/net/team2xh/scurses/EscapeCodes.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/EscapeCodes.scala
@@ -12,9 +12,9 @@ import java.io.OutputStream
 class EscapeCodes(out: OutputStream) {
 
   // Output an Escape Sequence
-  private def ESC(command: Char) { out.write(s"\033$command".getBytes) }
+  private def ESC(command: Char) { out.write(s"\u001b$command".getBytes) }
   // Output a Control Sequence Inroducer
-  private def CSI(sequence: String) { out.write(s"\033[$sequence".getBytes) }
+  private def CSI(sequence: String) { out.write(s"\u001b[$sequence".getBytes) }
   // Execute commands
   private def CSI(command: Char) { CSI(s"$command") }
   private def CSI(n: Int, command: Char) { CSI(s"$n$command") }


### PR DESCRIPTION
### What does this PR do?
Update versions for:
- Scala: 2.12.8 -> 2.13.0
- SBT: 1.2.8 -> 1.3.0 and plugins
- fast parse lib: 2.1.0 -> 2.1.3

Refactored code for Scala 2.13:
- Replaced **MutableList** with mutable **ArrayDeque**
- Replaced C-style octal escape sequences with Unicode analogs
### How to test?
Run examples.
