### PR TITLE
Add and apply scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+on:
+  pull_request:
+    branches: ['**']
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '2.7.5'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,13 @@
+version = 2.7.5
+preset = default
+align.preset = more
+maxColumn = 120
+project.git = true
+align.tokens.add = [
+  {code = ":=", owner = "Term.ApplyInfix"}
+]
+align.openParenDefnSite = true
+align.openParenCallSite = true
+align.arrowEnumeratorGenerator = true
+danglingParentheses.preset = true
+rewrite.rules = [RedundantBraces, RedundantParens]

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,13 @@ import xerial.sbt.Sonatype._
 
 ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / scalacOptions ++= Seq("-feature", "-unchecked")
-ThisBuild / organization := "net.team2xh"
-publishTo := sonatypePublishTo.value
-publishMavenStyle := true
+ThisBuild / organization        := "net.team2xh"
+publishTo                       := sonatypePublishTo.value
+publishMavenStyle               := true
 ThisBuild / sonatypeProfileName := "net.team2xh"
-ThisBuild / sonatypeProjectHosting := Some(GitHubHosting(user="Tenchi2xh", repository="Scurses", email="tenchi@team2xh.net"))
+ThisBuild / sonatypeProjectHosting := Some(
+  GitHubHosting(user = "Tenchi2xh", repository = "Scurses", email = "tenchi@team2xh.net")
+)
 ThisBuild / developers := List(
   Developer(id = "tenchi", name = "Hamza Haiken", email = "tenchi@team2xh.net", url = url("http://tenchi.me"))
 )
@@ -17,29 +19,29 @@ ThisBuild / licenses := Seq("MIT" -> url("https://github.com/Tenchi2xh/Scurses/b
 
 // This is causing problems with env variables being passed in, see
 // https://github.com/sbt/sbt/issues/6468
-ThisBuild / githubWorkflowUseSbtThinClient := false
+ThisBuild / githubWorkflowUseSbtThinClient      := false
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
 lazy val root = (project in file("."))
   .aggregate(scurses, onions)
   .settings(
-    publish / skip := true,
-    publishLocal / skip := true,
+    publish / skip       := true,
+    publishLocal / skip  := true,
     publishSigned / skip := true
   )
 
 lazy val scurses = (project in file("scurses"))
   .settings(
-    name := "scurses",
-    version := "1.0.1",
+    name                                 := "scurses",
+    version                              := "1.0.1",
     libraryDependencies += "com.lihaoyi" %% "fastparse" % "2.3.2",
-    Compile / run / mainClass := Some("net.team2xh.scurses.examples.GameOfLife")
+    Compile / run / mainClass            := Some("net.team2xh.scurses.examples.GameOfLife")
   )
 
 lazy val onions = (project in file("onions"))
   .dependsOn(scurses)
   .settings(
-    name := "onions",
-    version := "1.0.1",
+    name                      := "onions",
+    version                   := "1.0.1",
     Compile / run / mainClass := Some("net.team2xh.onions.examples.ExampleUI")
   )

--- a/onions/src/main/scala/net/team2xh/onions/Component.scala
+++ b/onions/src/main/scala/net/team2xh/onions/Component.scala
@@ -1,21 +1,17 @@
 package net.team2xh.onions
 
-import net.team2xh.onions.Themes.ColorScheme
-
 abstract class Component(parent: Option[Component]) {
 
   def innerWidth: Int
   def innerHeight: Int
 
-  def topLevel: Component = {
+  def topLevel: Component =
     parent match {
-      case None => this
+      case None    => this
       case Some(p) => p.topLevel
     }
-  }
 
-  def redraw(): Unit = {
+  def redraw(): Unit =
     topLevel.redraw()
-  }
 
 }

--- a/onions/src/main/scala/net/team2xh/onions/Palettes.scala
+++ b/onions/src/main/scala/net/team2xh/onions/Palettes.scala
@@ -1,8 +1,8 @@
 package net.team2xh.onions
 
-import java.awt.Color
-
 import net.team2xh.scurses.Colors
+
+import java.awt.Color
 
 object Palettes {
 
@@ -14,13 +14,11 @@ object Palettes {
     palette(i)
   }
 
-  def mapToRGB(value: Double, max: Double,
-               inverted: Boolean = false,
-               quadratic: Boolean = false): Int = {
+  def mapToRGB(value: Double, max: Double, inverted: Boolean = false, quadratic: Boolean = false): Int = {
 
     val normalized = if (!inverted) 1 - value / max else value / max
-    val squared = if (quadratic) normalized * normalized else normalized
-    val color = Color.getHSBColor(squared.toFloat * 0.6666666f, 0.75f, 1.0f)
+    val squared    = if (quadratic) normalized * normalized else normalized
+    val color      = Color.getHSBColor(squared.toFloat * 0.6666666f, 0.75f, 1.0f)
     Colors.fromRGBInt(color.getRGB)
   }
 

--- a/onions/src/main/scala/net/team2xh/onions/Symbols.scala
+++ b/onions/src/main/scala/net/team2xh/onions/Symbols.scala
@@ -4,27 +4,27 @@ object Symbols {
   // 1. Box-drawing
   // 1.1 Edges
   // 1.1.1 Vertical
-  val SV = "│"         // Single
-  val DV = "║"         // Double
-  val SV_TO_SL = "┤"   // Single to single left
-  val SV_TO_DL = "╡"   // Single to double left
-  val DV_TO_SL = "╢"   // Double to single left
-  val DV_TO_DL = "╣"   // Double to double left
-  val SV_TO_SR = "├"   // Single to single right
-  val SV_TO_DR = "╞"   // Single to double right
-  val DV_TO_SR = "╟"   // Double to double right
-  val DV_TO_DR = "╠"   // Double to double right
+  val SV       = "│" // Single
+  val DV       = "║" // Double
+  val SV_TO_SL = "┤" // Single to single left
+  val SV_TO_DL = "╡" // Single to double left
+  val DV_TO_SL = "╢" // Double to single left
+  val DV_TO_DL = "╣" // Double to double left
+  val SV_TO_SR = "├" // Single to single right
+  val SV_TO_DR = "╞" // Single to double right
+  val DV_TO_SR = "╟" // Double to double right
+  val DV_TO_DR = "╠" // Double to double right
   // 1.1.2 Horizontal
-  val SH = "─"         // Single
-  val DH = "═"         // Double
-  val SH_TO_SU = "┴"   // Single to single up
-  val SH_TO_DU = "╨"   // Single to double up
-  val DH_TO_SU = "╧"   // Double to single up
-  val DH_TO_DU = "╩"   // Double to double up
-  val SH_TO_SD = "┬"   // Single to single down
-  val SH_TO_DD = "╥"   // Single to double down
-  val DH_TO_SD = "╤"   // Double to single down
-  val DH_TO_DD = "╦"   // Double to double down
+  val SH       = "─" // Single
+  val DH       = "═" // Double
+  val SH_TO_SU = "┴" // Single to single up
+  val SH_TO_DU = "╨" // Single to double up
+  val DH_TO_SU = "╧" // Double to single up
+  val DH_TO_DU = "╩" // Double to double up
+  val SH_TO_SD = "┬" // Single to single down
+  val SH_TO_DD = "╥" // Single to double down
+  val DH_TO_SD = "╤" // Double to single down
+  val DH_TO_DD = "╦" // Double to double down
   // 1.2 Corners (parity is told clockwise)
   // 1.2.1 Top right corner
   val TRC_S_TO_S = "┐" // Single to single
@@ -47,10 +47,10 @@ object Symbols {
   val TLC_D_TO_S = "╓" // Double to single
   val TLC_D_TO_D = "╔" // Double to double
   // 1.3 Intersections
-  val SH_X_SV = "┼"    // Single horizontal cross single vertical
-  val SH_X_DV = "╫"    // Single horizontal cross double vertical
-  val DH_X_SV = "╪"    // Double horizontal cross single vertical
-  val DH_X_DV = "╬"    // Double horizontal cross double vertical
+  val SH_X_SV = "┼" // Single horizontal cross single vertical
+  val SH_X_DV = "╫" // Single horizontal cross double vertical
+  val DH_X_SV = "╪" // Double horizontal cross single vertical
+  val DH_X_DV = "╬" // Double horizontal cross double vertical
   // 2. Block symbols
   val BLOCK       = "█"
   val BLOCK_75    = "▓"

--- a/onions/src/main/scala/net/team2xh/onions/Themes.scala
+++ b/onions/src/main/scala/net/team2xh/onions/Themes.scala
@@ -1,7 +1,5 @@
 package net.team2xh.onions
 
-import net.team2xh.scurses.Colors
-
 object Themes {
 
   sealed trait ColorScheme {
@@ -17,33 +15,33 @@ object Themes {
   }
 
   val default = new ColorScheme {
-    override val foreground = 15
-    override val background = 0
+    override val foreground      = 15
+    override val background      = 0
     override val focusForeground = 0
     override val focusBackground = 15
-    override val accent1 = 237
-    override val accent2 = 248
-    override val accent3 = 250
+    override val accent1         = 237
+    override val accent2         = 248
+    override val accent3         = 250
   }
 
   val light = new ColorScheme {
-    override val foreground: Int = 242
-    override val background: Int = 255
+    override val foreground: Int      = 242
+    override val background: Int      = 255
     override val focusForeground: Int = 0
     override val focusBackground: Int = 251
-    override val accent1: Int = 253
-    override val accent3: Int = 252
-    override val accent2: Int = 249
+    override val accent1: Int         = 253
+    override val accent3: Int         = 252
+    override val accent2: Int         = 249
   }
 
   val MSDOS = new ColorScheme {
-    override val foreground: Int = 248
-    override val background: Int = 4
+    override val foreground: Int      = 248
+    override val background: Int      = 4
     override val focusForeground: Int = 0
     override val focusBackground: Int = foreground
-    override val accent1: Int = 6
-    override val accent3: Int = 8
-    override val accent2: Int = 11
+    override val accent1: Int         = 6
+    override val accent3: Int         = 8
+    override val accent2: Int         = 11
   }
 
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
@@ -1,16 +1,15 @@
 package net.team2xh.onions.components
 
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.{Symbols, Component}
-import net.team2xh.scurses.Scurses
+import net.team2xh.onions.{Component, Symbols}
 import net.team2xh.scurses.RichText.RichTextHelper
+import net.team2xh.scurses.Scurses
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 object FramePanel {
-  def expandRight(parent: FramePanel)
-                 (implicit screen: Scurses): FramePanel = {
+  def expandRight(parent: FramePanel)(implicit screen: Scurses): FramePanel = {
     val newRight = new FramePanel(parent)
     newRight.right = parent.right
     newRight.left = Some(parent)
@@ -19,8 +18,7 @@ object FramePanel {
     newRight
   }
 
-  def expandDown(parent: FramePanel)
-                (implicit screen: Scurses): FramePanel = {
+  def expandDown(parent: FramePanel)(implicit screen: Scurses): FramePanel = {
     val newBottom = new FramePanel(parent)
     newBottom.bottom = parent.bottom
     newBottom.top = Some(parent)
@@ -32,18 +30,17 @@ object FramePanel {
   var idCounter = 0
 }
 
-case class FramePanel(parent: Component)
-                     (implicit screen: Scurses) extends Component(Some(parent)) {
+case class FramePanel(parent: Component)(implicit screen: Scurses) extends Component(Some(parent)) {
 
-  var width = 0
+  var width  = 0
   var height = 0
 
   var title = ""
 
-  var top:    Option[FramePanel] = None
+  var top: Option[FramePanel]    = None
   var bottom: Option[FramePanel] = None
-  var left:   Option[FramePanel] = None
-  var right:  Option[FramePanel] = None
+  var left: Option[FramePanel]   = None
+  var right: Option[FramePanel]  = None
 
   var focus = false
 
@@ -53,14 +50,14 @@ case class FramePanel(parent: Component)
   var tabs =
     mutable.ArrayDeque[(ListBuffer[Widget], Int, ListBuffer[Int])]((ListBuffer[Widget](), 0, ListBuffer[Int]()))
 
-  def widgets = tabs(currentTab)._1
+  def widgets     = tabs(currentTab)._1
   def widgetFocus = tabs(currentTab)._2
-  def heights = tabs(currentTab)._3
+  def heights     = tabs(currentTab)._3
 
   val id = FramePanel.idCounter
   FramePanel.idCounter += 1
 
-  def innerWidth = width
+  def innerWidth  = width
   def innerHeight = height
 
   def addWidget(widget: Widget): Unit = {
@@ -98,17 +95,17 @@ case class FramePanel(parent: Component)
 
   private[components] def updateDimensions(newWidth: Int, newHeight: Int): Unit = {
     val (_, nHorizontal) = totalHorizontal
-    val newColumnWidth = newWidth / nHorizontal
+    val newColumnWidth   = newWidth / nHorizontal
     right match {
       case None => width = newWidth - (nHorizontal - 1) * newColumnWidth
-      case _ => width = newColumnWidth
+      case _    => width = newColumnWidth
     }
 
     val (_, nVertical) = totalVertical
-    val newRowHeight = newHeight / nVertical
+    val newRowHeight   = newHeight / nVertical
     bottom match {
       case None => height = newHeight - (nVertical - 1) * newRowHeight
-      case _ => height = newRowHeight
+      case _    => height = newRowHeight
     }
 
     bottom.foreach(_.updateDimensions(if (left.isEmpty) newWidth else width, newHeight))
@@ -117,32 +114,30 @@ case class FramePanel(parent: Component)
 
   def getTreeWalk: Seq[FramePanel] = {
     val b = bottom match {
-      case None => Seq()
+      case None        => Seq()
       case Some(panel) => panel.getTreeWalk
     }
     val r = right match {
-      case None => Seq()
+      case None        => Seq()
       case Some(panel) => panel.getTreeWalk
     }
     this +: (b ++ r)
   }
 
-  def getFocusedWidget: Option[Widget] = {
+  def getFocusedWidget: Option[Widget] =
     if (widgetFocus < widgets.length)
       Some(widgets(widgetFocus))
     else
       None
-  }
 
   def previousFocusableWidget: Option[Int] = {
     val l = widgets.length
     if (l == 0 || widgetFocus == 0)
       None
     else {
-      for (i <- widgetFocus - 1 to 0 by -1) {
+      for (i <- widgetFocus - 1 to 0 by -1)
         if (widgets(i).focusable)
           return Some(i)
-      }
       None
     }
   }
@@ -152,15 +147,14 @@ case class FramePanel(parent: Component)
     if (l == 0 || widgetFocus >= l - 1)
       None
     else {
-      for (i <- widgetFocus + 1 until l) {
+      for (i <- widgetFocus + 1 until l)
         if (widgets(i).focusable)
           return Some(i)
-      }
       None
     }
   }
 
-  def focusSomeWidget(which: Option[Int]): Boolean = {
+  def focusSomeWidget(which: Option[Int]): Boolean =
     which match {
       case None => false
       case Some(i) =>
@@ -169,30 +163,28 @@ case class FramePanel(parent: Component)
         tabs(currentTab) = (widgets, i, heights)
         true
     }
-  }
 
   def focusPreviousWidget = focusSomeWidget(previousFocusableWidget)
 
   def focusNextWidget = focusSomeWidget(nextFocusableWidget)
 
-  def markAllForRedraw(): Unit = {
+  def markAllForRedraw(): Unit =
     getTreeWalk.foreach { panel =>
       panel.redrawBorders = true
       panel.widgets.foreach(_.needsRedraw = true)
     }
-  }
 
   def getNextDirection(direction: (FramePanel) => Option[FramePanel],
-                   fallback: (FramePanel) => Option[FramePanel]): Option[FramePanel] = {
+                       fallback: (FramePanel) => Option[FramePanel]
+  ): Option[FramePanel] =
     direction(this) match {
       case Some(panel) => Some(panel)
       case None =>
         fallback(this) match {
           case Some(panel) => panel.getNextDirection(direction, fallback)
-          case None => None
+          case None        => None
         }
     }
-  }
 
   private[FramePanel] def totalHorizontal: (Int, Int) = {
     val l = total(_.left, _.width)
@@ -206,15 +198,13 @@ case class FramePanel(parent: Component)
     (t._1 + height + b._1, t._2 + 1 + b._2)
   }
 
-  private[FramePanel] def total(direction: (FramePanel) => Option[FramePanel],
-                                attribute: (FramePanel) => Int): (Int, Int) = {
+  private[FramePanel] def total(direction: FramePanel => Option[FramePanel], attribute: FramePanel => Int): (Int, Int) =
     direction(this) match {
       case None => (0, 0)
       case Some(panel) =>
         val l = panel.total(direction, attribute)
         (l._1 + attribute(panel), l._2 + 1)
     }
-  }
 
   private[FramePanel] def resizeHorizontal(columnWidth: Int): Unit = {
     resize(_.left, _.width = columnWidth)
@@ -226,35 +216,28 @@ case class FramePanel(parent: Component)
     resize(_.bottom, _.height = rowHeight)
   }
 
-  private[FramePanel] def resize(direction: (FramePanel) => Option[FramePanel],
-                                 setter: (FramePanel) => Unit): Unit = {
-    direction(this) foreach {
-      panel =>
-        setter(panel)
-        panel.resize(direction, setter)
+  private[FramePanel] def resize(direction: FramePanel => Option[FramePanel], setter: FramePanel => Unit): Unit =
+    direction(this) foreach { panel =>
+      setter(panel)
+      panel.resize(direction, setter)
     }
-  }
 
-  /**
-   * Splits this panel vertically.
-   * @return Right panel resulting from the split
-   */
-  def splitRight: FramePanel = {
+  /** Splits this panel vertically.
+    * @return Right panel resulting from the split
+    */
+  def splitRight: FramePanel =
     FramePanel.expandRight(this)
-  }
 
-  /**
-   * Splits this panel horizontally.
-   * @return Bottom panel resulting from the slice
-   */
-  def splitDown: FramePanel = {
+  /** Splits this panel horizontally.
+    * @return Bottom panel resulting from the slice
+    */
+  def splitDown: FramePanel =
     FramePanel.expandDown(this)
-  }
 
   private[FramePanel] def hasAnyLeft: Boolean = left match {
     case None =>
       top match {
-        case None => false
+        case None        => false
         case Some(panel) => panel.hasAnyLeft
       }
     case Some(panel) => true
@@ -263,7 +246,7 @@ case class FramePanel(parent: Component)
   private[FramePanel] def hasAnyRight: Boolean = right match {
     case None =>
       top match {
-        case None => false
+        case None        => false
         case Some(panel) => panel.hasAnyRight
       }
     case Some(panel) => true
@@ -274,62 +257,62 @@ case class FramePanel(parent: Component)
 
     // Vertical edges
     for (y <- 1 to height - 1) {
-      screen.put(width, y, Symbols.SV,
-        foreground = theme.foreground, background = theme.background)
+      screen.put(width, y, Symbols.SV, foreground = theme.foreground, background = theme.background)
       if (left.isEmpty)
-        screen.put(0, y, Symbols.SV,
-          foreground = theme.foreground, background = theme.background)
+        screen.put(0, y, Symbols.SV, foreground = theme.foreground, background = theme.background)
     }
     // Horizontal edges
-    screen.put(1, 0, Symbols.SH * (width - 1),
-      foreground = theme.foreground, background = theme.background)
+    screen.put(1, 0, Symbols.SH * (width - 1), foreground = theme.foreground, background = theme.background)
     if (bottom.isEmpty)
-      screen.put(1, height, Symbols.SH * (width - 1),
-        foreground = theme.foreground, background = theme.background)
+      screen.put(1, height, Symbols.SH * (width - 1), foreground = theme.foreground, background = theme.background)
   }
 
   private[FramePanel] def drawCorners(theme: ColorScheme): Unit = {
     propagateDraw(_.drawCorners(theme))
 
     // Top-left corner
-    val tlc = if (left.isEmpty)
-      if (top.isEmpty)
-        Symbols.TLC_S_TO_S
+    val tlc =
+      if (left.isEmpty)
+        if (top.isEmpty)
+          Symbols.TLC_S_TO_S
+        else
+          Symbols.SV_TO_SR
+      else if (top.isEmpty)
+        Symbols.SH_TO_SD
       else
-        Symbols.SV_TO_SR
-    else if (top.isEmpty)
-      Symbols.SH_TO_SD
-    else
-      Symbols.SH_X_SV
+        Symbols.SH_X_SV
     // Bottom-left corner
     // ┼ not supported
-    val blc = if (hasAnyLeft)
-      if (bottom.isEmpty)
-        Symbols.SH_TO_SU
+    val blc =
+      if (hasAnyLeft)
+        if (bottom.isEmpty)
+          Symbols.SH_TO_SU
+        else
+          Symbols.SV_TO_SR
       else
-        Symbols.SV_TO_SR
-    else
-      Symbols.BLC_S_TO_S
+        Symbols.BLC_S_TO_S
     // Bottom-right corner
-    val brc = if (hasAnyRight)
-      if (bottom.isEmpty)
-        Symbols.SH_TO_SU
+    val brc =
+      if (hasAnyRight)
+        if (bottom.isEmpty)
+          Symbols.SH_TO_SU
+        else
+          Symbols.SV_TO_SL
+      else if (bottom.isEmpty)
+        Symbols.BRC_S_TO_S
       else
         Symbols.SV_TO_SL
-    else if (bottom.isEmpty)
-      Symbols.BRC_S_TO_S
-    else
-      Symbols.SV_TO_SL
     // Top-right corner
-    val trc = if (top.isEmpty)
-      if (right.isEmpty)
-        Symbols.TRC_S_TO_S
+    val trc =
+      if (top.isEmpty)
+        if (right.isEmpty)
+          Symbols.TRC_S_TO_S
+        else
+          Symbols.SH_TO_SD
+      else if (right.isEmpty)
+        Symbols.SV_TO_SL
       else
         Symbols.SH_TO_SD
-    else if (right.isEmpty)
-      Symbols.SV_TO_SL
-    else
-      Symbols.SH_TO_SD
     // Draw
     screen.put(0, 0, tlc, foreground = theme.foreground, background = theme.background)
     screen.put(0, height, blc, foreground = theme.foreground, background = theme.background)
@@ -340,11 +323,13 @@ case class FramePanel(parent: Component)
 
   private[FramePanel] def drawTitles(theme: ColorScheme): Unit = {
     propagateDraw(_.drawTitles(theme))
-    val ts = tabs.zipWithIndex.map { case (t, i) =>
-      val s = if (i == currentTab) "[r]" else ""
-      val e = if (i == currentTab) "[/r]" else ""
-      s"$s#${i+1}$e"
-    }.mkString("|")
+    val ts = tabs.zipWithIndex
+      .map { case (t, i) =>
+        val s = if (i == currentTab) "[r]" else ""
+        val e = if (i == currentTab) "[/r]" else ""
+        s"$s#${i + 1}$e"
+      }
+      .mkString("|")
 
     val tabText =
       if (tabs.length == 1) ""
@@ -360,10 +345,12 @@ case class FramePanel(parent: Component)
   private[components] def drawDebug(theme: ColorScheme): Unit = {
     propagateDraw(_.drawDebug(theme))
 
+    // format: off
     val neighbours = "%s%s%s%s".format(if (top.isDefined)    "↑" else "",
                                        if (bottom.isDefined) "↓" else "",
                                        if (left.isDefined)   "←" else "",
                                        if (right.isDefined)  "→" else "")
+    // format: on
 
     val line = s"(#$id|${width}x$height|$neighbours)"
     screen.put(width - 1 - line.length, 0, line, foreground = theme.accent2, background = theme.background)
@@ -373,9 +360,8 @@ case class FramePanel(parent: Component)
     propagateDraw(_.fillBoxes(theme))
 
     if (needsClear) {
-      for (y <- 1 to height - 1) {
+      for (y <- 1 to height - 1)
         screen.put(1, y, " " * (width - 1), background = theme.background)
-      }
       needsClear = false
     }
   }
@@ -384,14 +370,30 @@ case class FramePanel(parent: Component)
     propagateDraw(_.drawFocusIndicator(theme))
 
     val indicator = theme.accent1
-    screen.put(1, 1, if (focus) Symbols.BLOCK + Symbols.BLOCK_UPPER else "  ",
-      foreground = indicator, background = theme.background)
-    screen.put(1, height - 1, if (focus) Symbols.BLOCK + Symbols.BLOCK_LOWER else "  ",
-      foreground = indicator, background = theme.background)
-    screen.put(width - 2, 1, if (focus) Symbols.BLOCK_UPPER + Symbols.BLOCK else "  ",
-      foreground = indicator, background = theme.background)
-    screen.put(width - 2, height - 1, if (focus) Symbols.BLOCK_LOWER + Symbols.BLOCK else "  ",
-      foreground = indicator, background = theme.background)
+    screen.put(1,
+               1,
+               if (focus) Symbols.BLOCK + Symbols.BLOCK_UPPER else "  ",
+               foreground = indicator,
+               background = theme.background
+    )
+    screen.put(1,
+               height - 1,
+               if (focus) Symbols.BLOCK + Symbols.BLOCK_LOWER else "  ",
+               foreground = indicator,
+               background = theme.background
+    )
+    screen.put(width - 2,
+               1,
+               if (focus) Symbols.BLOCK_UPPER + Symbols.BLOCK else "  ",
+               foreground = indicator,
+               background = theme.background
+    )
+    screen.put(width - 2,
+               height - 1,
+               if (focus) Symbols.BLOCK_LOWER + Symbols.BLOCK else "  ",
+               foreground = indicator,
+               background = theme.background
+    )
 
   }
 
@@ -413,15 +415,14 @@ case class FramePanel(parent: Component)
     propagateDraw(_.drawWidgets(theme))
 
     screen.clip(width, height - 1)
-    var y = 2
+    var y             = 2
     var heightChanged = false
     for ((widget, i) <- widgets.zipWithIndex) {
       if (widget.needsRedraw) {
         screen.translateOffset(x = 2, y = y)
         // clear widget's space first
-        for (y <- 0 until widget.innerHeight) {
+        for (y <- 0 until widget.innerHeight)
           screen.put(0, y, " " * widget.innerWidth, background = theme.background)
-        }
         widget.draw(focus && widgetFocus == i, theme)
         screen.translateOffset(x = -2, y = -y)
       }
@@ -430,19 +431,17 @@ case class FramePanel(parent: Component)
       // If the height changed, redraw the rest
       if (heights(i) != newHeight) {
         heightChanged = true
-        for (j <- i + 1 until widgets.length) {
+        for (j <- i + 1 until widgets.length)
           widgets(j).needsRedraw = true
-        }
       }
       heights(i) = newHeight
     }
     // Clear the rest of the panel if heights have changed
-    for (y <- y to height - 1) {
+    for (y <- y to height - 1)
       screen.put(1, y, " " * (width - 1), background = theme.background)
-    }
     screen.unclip()
   }
-  
+
   def propagateDraw(drawMethod: (FramePanel) => Unit): Unit = {
     screen.translateOffset(y = height)
     bottom.foreach(b => drawMethod(b))
@@ -452,22 +451,22 @@ case class FramePanel(parent: Component)
   }
 
   private[components] def horizontalDepth: Int = right match {
-    case None => 1
+    case None        => 1
     case Some(panel) => 1 + panel.horizontalDepth
   }
 
   private[components] def verticalDepth: Int = bottom match {
-    case None => 1
+    case None        => 1
     case Some(panel) => 1 + panel.verticalDepth
   }
 
   private[components] def maxVerticalDepth: Int = right match {
-    case None => verticalDepth
+    case None        => verticalDepth
     case Some(panel) => math.max(verticalDepth, panel.maxVerticalDepth)
   }
 
   private[components] def verticalDepths: Seq[Int] = right match {
-    case None => Seq(verticalDepth)
+    case None        => Seq(verticalDepth)
     case Some(panel) => Seq(verticalDepth) ++ panel.verticalDepths
   }
 

--- a/onions/src/main/scala/net/team2xh/onions/components/Widget.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/Widget.scala
@@ -5,15 +5,15 @@ import net.team2xh.onions.Themes.ColorScheme
 import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.Scurses
 
-abstract class Widget(parent: FramePanel, values: Varying[_] *)
-                     (implicit screen: Scurses) extends Component(Some(parent)) {
+abstract class Widget(parent: FramePanel, values: Varying[_]*)(implicit screen: Scurses)
+    extends Component(Some(parent)) {
 
   parent.addWidget(this)
 
   for (value <- values)
-    value.subscribe(() => {
+    value.subscribe { () =>
       needsRedraw = true
-    })
+    }
 
   def focusable: Boolean
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/BarChart.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/BarChart.scala
@@ -1,73 +1,92 @@
 package net.team2xh.onions.components.widgets
 
-import java.text.DecimalFormat
-
 import net.team2xh.onions.Themes.ColorScheme
 import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Math, Varying}
 import net.team2xh.onions.{Palettes, Symbols}
 import net.team2xh.scurses.Scurses
 
+import java.text.DecimalFormat
 import scala.Numeric.Implicits._
 
-/**
- * Widget that displays a horizontal bar chart, given a sequence of values.
- *
- * @param parent     Parent panel in which the widget will be added
- * @param values     Sequence of values to display on the chart
- * @param labels     Sequence of names (labels) associated with each value, in order
- * @param min        Minimum value to display on the chart (scales to content by default)
- * @param max        Maximum value to display on the chart (scales to content by default)
- * @param palette    Color palette to use for the bars
- * @param showLabels Enables the display of the labels
- * @param showValues Enables the display of the axis values
- * @param screen     Implicit Scurses screen
- */
-case class BarChart[T: Numeric](parent: FramePanel, values: Varying[Seq[T]], labels: Seq[String] = Seq(),
-                                min: Option[Int] = None, max: Option[Int] = None,
+/** Widget that displays a horizontal bar chart, given a sequence of values.
+  *
+  * @param parent     Parent panel in which the widget will be added
+  * @param values     Sequence of values to display on the chart
+  * @param labels     Sequence of names (labels) associated with each value, in order
+  * @param min        Minimum value to display on the chart (scales to content by default)
+  * @param max        Maximum value to display on the chart (scales to content by default)
+  * @param palette    Color palette to use for the bars
+  * @param showLabels Enables the display of the labels
+  * @param showValues Enables the display of the axis values
+  * @param screen     Implicit Scurses screen
+  */
+case class BarChart[T: Numeric](parent: FramePanel,
+                                values: Varying[Seq[T]],
+                                labels: Seq[String] = Seq(),
+                                min: Option[Int] = None,
+                                max: Option[Int] = None,
                                 palette: Seq[Int] = Palettes.default,
-                                showLabels: Boolean = true, showValues: Boolean = true)
-                               (implicit screen: Scurses) extends Widget(parent, values) {
+                                showLabels: Boolean = true,
+                                showValues: Boolean = true
+)(implicit screen: Scurses)
+    extends Widget(parent, values) {
 
-  val gridWidth = 4
+  val gridWidth                   = 4
   override def focusable: Boolean = false
-  override def innerHeight: Int = parent.innerHeight - 3
+  override def innerHeight: Int   = parent.innerHeight - 3
 
   val df = new DecimalFormat("#.#")
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     val vs = values.value
     // If not enough labels were specified, name them according to their order
-    val ls = labels.take(vs.length) ++ (labels.length until vs.length).map(n => "#" + (n+1).toString)
+    val ls = labels.take(vs.length) ++ (labels.length until vs.length).map(n => "#" + (n + 1).toString)
     // Width of the largest label
     val labelLength = ls.map(_.length).max
     // Width of the chart itself
-    val graphWidth = if (showLabels) innerWidth - labelLength - 4 else innerWidth - 1
+    val graphWidth  = if (showLabels) innerWidth - labelLength - 4 else innerWidth - 1
     val graphHeight = innerHeight - 2
-    val valueMin = min.getOrElse(Math.aBitLessThanMin(vs))
-    val valueMax = max.getOrElse(Math.aBitMoreThanMax(vs))
+    val valueMin    = min.getOrElse(Math.aBitLessThanMin(vs))
+    val valueMax    = max.getOrElse(Math.aBitMoreThanMax(vs))
     // Draw grid
-    Drawing.drawGrid(0, 0, graphWidth, graphHeight, gridWidth, theme.accent1, theme.background,
-                     showVertical = true, showHorizontal = false)
+    Drawing.drawGrid(0,
+                     0,
+                     graphWidth,
+                     graphHeight,
+                     gridWidth,
+                     theme.accent1,
+                     theme.background,
+                     showVertical = true,
+                     showHorizontal = false
+    )
     // Draw bars
-    val spacing = graphHeight / (vs.length - 1)
+    val spacing  = graphHeight / (vs.length - 1)
     val spaceTop = (graphHeight - (vs.length - 1) * spacing - 1) / 2
-    val zero = math.floor(((0 - valueMin) * graphWidth.toDouble) / (valueMax - valueMin)).toInt
+    val zero     = math.floor(((0 - valueMin) * graphWidth.toDouble) / (valueMax - valueMin)).toInt
     for ((y, i) <- (spaceTop until spaceTop + vs.length * spacing by spacing).zipWithIndex) {
       val length = math.round(((vs(i).toDouble - valueMin) * graphWidth) / (valueMax - valueMin)).toInt
       // Draw the bars themselves
       if (vs(i).toDouble >= 0) {
-        screen.put(zero, 1 + y, Symbols.BLOCK_RIGHT + Symbols.BLOCK * (length-zero) + Symbols.BLOCK_LEFT,
-          foreground = palette(i % palette.length), background = theme.background)
+        screen.put(zero,
+                   1 + y,
+                   Symbols.BLOCK_RIGHT + Symbols.BLOCK * (length - zero) + Symbols.BLOCK_LEFT,
+                   foreground = palette(i % palette.length),
+                   background = theme.background
+        )
       } else {
-        screen.put(length - 1, 1 + y, Symbols.BLOCK_RIGHT + Symbols.BLOCK * (zero-length) + Symbols.BLOCK_LEFT,
-          foreground = palette(i % palette.length), background = theme.background)
+        screen.put(length - 1,
+                   1 + y,
+                   Symbols.BLOCK_RIGHT + Symbols.BLOCK * (zero - length) + Symbols.BLOCK_LEFT,
+                   foreground = palette(i % palette.length),
+                   background = theme.background
+        )
       }
       // Draw values
       val valuePos = if (vs(i).toInt >= 0) length + 2 else zero + 1
       val text = vs(i) match {
         case _: Double => df.format(vs(i).toDouble)
-        case _: Int => vs(i).toString
+        case _: Int    => vs(i).toString
       }
       if (showValues)
         screen.put(valuePos, 1 + y, text, foreground = theme.foreground, background = theme.background)
@@ -77,16 +96,31 @@ case class BarChart[T: Numeric](parent: FramePanel, values: Varying[Seq[T]], lab
     val spaceTopLabels = (graphHeight - vs.length) / 2
     if (showLabels)
       for (i <- vs.indices) {
-        screen.put(graphWidth + 2, 1 + spaceTopLabels + i, Symbols.SQUARE,
-          foreground = palette(i % palette.length), background = theme.background)
-        screen.put(graphWidth + 4, 1 + spaceTopLabels + i, ls(i),
-          foreground = theme.accent3, background = theme.background)
+        screen.put(graphWidth + 2,
+                   1 + spaceTopLabels + i,
+                   Symbols.SQUARE,
+                   foreground = palette(i % palette.length),
+                   background = theme.background
+        )
+        screen.put(graphWidth + 4,
+                   1 + spaceTopLabels + i,
+                   ls(i),
+                   foreground = theme.accent3,
+                   background = theme.background
+        )
       }
     // Draw grid values
-    Drawing.drawAxisValues(0, innerHeight - 1, graphWidth, gridWidth, valueMin, valueMax,
-                           theme.accent3, theme.background, horizontal = true)
+    Drawing.drawAxisValues(0,
+                           innerHeight - 1,
+                           graphWidth,
+                           gridWidth,
+                           valueMin,
+                           valueMax,
+                           theme.accent3,
+                           theme.background
+    )
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/BigText.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/BigText.scala
@@ -3,13 +3,14 @@ package net.team2xh.onions.components.widgets
 import net.team2xh.onions.components.FramePanel
 import net.team2xh.onions.components.widgets.BigText.{empty, symbols}
 import net.team2xh.onions.utils.Varying
-import net.team2xh.scurses.{Colors, Scurses}
+import net.team2xh.scurses.Scurses
 
-case class BigText(parent: FramePanel, text: Varying[String])
-                  (implicit screen: Scurses) extends FontMapper(parent, empty, symbols, text, -1)
+case class BigText(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
+    extends FontMapper(parent, empty, symbols, text, -1)
 
 object BigText {
   var empty = Seq("", "", "")
+  // format: off
   val symbols = Map(
     'a' -> Seq(
       "┌─┐",
@@ -172,4 +173,5 @@ object BigText {
       "─",
       " ")
   )
+  // format: on
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/BitMap.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/BitMap.scala
@@ -1,33 +1,31 @@
 package net.team2xh.onions.components.widgets
 
-import java.awt.image.BufferedImage
-import java.io.File
-import javax.imageio.ImageIO
-
 import net.team2xh.onions.Symbols
 import net.team2xh.onions.Themes.ColorScheme
 import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.scurses.{Colors, Scurses}
 
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
 object BitMap {
 
   def apply(parent: FramePanel, path: String, relative: Boolean = false)(implicit screen: Scurses): BitMap = {
     val fullPath = if (relative) new File("").getAbsolutePath + path else path
-    val image = ImageIO.read(new File(fullPath))
+    val image    = ImageIO.read(new File(fullPath))
     new BitMap(parent, image)
   }
 
-  def apply(parent: FramePanel, image: BufferedImage)(implicit screen: Scurses): BitMap = {
+  def apply(parent: FramePanel, image: BufferedImage)(implicit screen: Scurses): BitMap =
     new BitMap(parent, image)
-  }
 
 }
 
-class BitMap(parent: FramePanel, image: BufferedImage)
-                 (implicit screen: Scurses) extends Widget(parent) {
+class BitMap(parent: FramePanel, image: BufferedImage)(implicit screen: Scurses) extends Widget(parent) {
 
   val colors = {
-    val width = image.getWidth
+    val width  = image.getWidth
     val height = image.getHeight
     for (x <- 0 until width)
       yield for (y <- 0 until height / 2) yield {
@@ -40,18 +38,17 @@ class BitMap(parent: FramePanel, image: BufferedImage)
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     val width = image.getWidth min innerWidth
-    val x0 = (innerWidth - width) / 2
-    for (x <- 0 until width) {
+    val x0    = (innerWidth - width) / 2
+    for (x <- 0 until width)
       for (y <- 0 until innerHeight) {
         // Read two rows at a time
         val c = colors(x)(y)
         screen.put(x0 + x, y, Symbols.BLOCK_UPPER, c._1, c._2)
       }
-    }
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def focusable: Boolean = false
-  override def innerHeight: Int = image.getHeight / 2
+  override def innerHeight: Int   = image.getHeight / 2
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/CheckBox.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/CheckBox.scala
@@ -1,31 +1,26 @@
 package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class CheckBox(parent: FramePanel,
-                    text: String,
-                    checked: Varying[Boolean] = false)
-                   (implicit screen: Scurses) extends Widget(parent, checked) {
+case class CheckBox(parent: FramePanel, text: String, checked: Varying[Boolean] = false)(implicit screen: Scurses)
+    extends Widget(parent, checked) {
 
   def focusable = true
 
   def drawText(foreground: Int, background: Int): Unit = {
     val line = " [%s] %s".format(if (checked.value) "√" else " ", Drawing.clipText(text, innerWidth - 7))
-    screen.put(0, 0, line + " " * (innerWidth - line.length - 1),
-      foreground = foreground, background = background)
+    screen.put(0, 0, line + " " * (innerWidth - line.length - 1), foreground = foreground, background = background)
   }
 
-  override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
+  override def redraw(focus: Boolean, theme: ColorScheme): Unit =
     drawText(theme.foreground(focus), theme.background(focus))
-  }
 
-  override def handleKeypress(keypress: Int): Unit = {
+  override def handleKeypress(keypress: Int): Unit =
     if (keypress == Keys.ENTER || keypress == Keys.SPACE)
       checked := !checked.value
-  }
 
   override def innerHeight: Int = 1
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/FontMapper.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/FontMapper.scala
@@ -1,14 +1,17 @@
 package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.Varying
-import net.team2xh.scurses.{Scurses, Colors}
+import net.team2xh.scurses.{Colors, Scurses}
 
-abstract class FontMapper(parent: FramePanel, empty: Seq[String],
-                          symbols: Map[Char, Seq[String]], text: Varying[String],
-                          var color: Varying[Int] = Colors.BRIGHT_WHITE)
-                         (implicit screen: Scurses) extends Widget(parent, text, color) {
+abstract class FontMapper(parent: FramePanel,
+                          empty: Seq[String],
+                          symbols: Map[Char, Seq[String]],
+                          text: Varying[String],
+                          var color: Varying[Int] = Colors.BRIGHT_WHITE
+)(implicit screen: Scurses)
+    extends Widget(parent, text, color) {
 
   override def focusable: Boolean = false
 
@@ -17,7 +20,7 @@ abstract class FontMapper(parent: FramePanel, empty: Seq[String],
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     val t = text.value
     val h = empty.length
-    if (!t.isEmpty) {
+    if (t.nonEmpty) {
       val charsSymbols = t.toLowerCase.map(c => (c, symbols.getOrElse(c, empty).head.length))
       val wrapped = charsSymbols.foldLeft(Seq[(String, Int)](("", 0))) { case (accu, (c, l)) =>
         val current = accu.last
@@ -30,18 +33,21 @@ abstract class FontMapper(parent: FramePanel, empty: Seq[String],
       val wrappedText = wrapped.map(_._1)
       height = wrapped.length * empty.length
       val width = wrapped.maxBy(_._2)._2
-      val c = if (color.value < 0) theme.foreground else color.value
+      val c     = if (color.value < 0) theme.foreground else color.value
       for ((chunk, i) <- wrappedText.zipWithIndex) {
         val chars = chunk.toLowerCase.map(symbols.getOrElse(_, empty) ++ Seq("    "))
-        for (y <- 0 until h) {
-          screen.put((innerWidth - width) / 2, y + i * 3, ("" /: chars)((line, char) => line + char(y)),
-            foreground = c, background = theme.background)
-        }
+        for (y <- 0 until h)
+          screen.put((innerWidth - width) / 2,
+                     y + i * 3,
+                     ("" /: chars)((line, char) => line + char(y)),
+                     foreground = c,
+                     background = theme.background
+          )
       }
     }
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def innerHeight: Int = height
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/HeatMap.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/HeatMap.scala
@@ -9,10 +9,14 @@ import net.team2xh.scurses.Scurses
 
 import scala.Numeric.Implicits._
 
-case class HeatMap[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T)]],
-                               labelX: String = "", labelY: String = "",
-                               radius: Varying[Int] = 5, showLabels: Boolean = false)
-                              (implicit screen: Scurses) extends Widget(parent, values, radius) {
+case class HeatMap[T: Numeric](parent: FramePanel,
+                               values: Varying[Seq[(T, T)]],
+                               labelX: String = "",
+                               labelY: String = "",
+                               radius: Varying[Int] = 5,
+                               showLabels: Boolean = false
+)(implicit screen: Scurses)
+    extends Widget(parent, values, radius) {
 
   val gridSize = 8
 
@@ -25,15 +29,24 @@ case class HeatMap[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T)]],
     val minY = Math.aBitLessThanMin(ys)
 
     val valuesLength = maxY.toString.length max minY.toString.length
-    val x0 = valuesLength + (if (showLabels) 2 else 0)
-    val graphWidth = (if (showLabels) innerWidth - 2 else innerWidth) - valuesLength
-    val graphHeight = if (showLabels) innerHeight - 3 else innerHeight - 2
+    val x0           = valuesLength + (if (showLabels) 2 else 0)
+    val graphWidth   = (if (showLabels) innerWidth - 2 else innerWidth) - valuesLength
+    val graphHeight  = if (showLabels) innerHeight - 3 else innerHeight - 2
 
     // Draw grid
 //    Drawing.drawGrid(x0, 0, graphWidth, graphHeight, gridSize, theme.accent1, theme.background,
 //      showVertical = false, showHorizontal = false)
     // Draw axis values
-    Drawing.drawAxisValues(x0 - valuesLength, 0, graphHeight, gridSize, minY, maxY, theme.accent3, theme.background, horizontal = false)
+    Drawing.drawAxisValues(x0 - valuesLength,
+                           0,
+                           graphHeight,
+                           gridSize,
+                           minY,
+                           maxY,
+                           theme.accent3,
+                           theme.background,
+                           horizontal = false
+    )
     Drawing.drawAxisValues(x0, graphHeight + 1, graphWidth, gridSize, minX, maxX, theme.accent3, theme.background)
 
     // Draw labels
@@ -43,7 +56,7 @@ case class HeatMap[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T)]],
 
     // Prepare data
     // for each point of data, put a gaussian on the 2d array around its coordinate
-    val dh = graphHeight * 2
+    val dh    = graphHeight * 2
     val array = GaussianArray(graphWidth, dh + 2, kernelRadius = radius.value)
     for (value <- values.value) {
       val nx = math.round((graphWidth * (value._1.toDouble - minX)) / (maxX - minX)).toInt
@@ -61,8 +74,8 @@ case class HeatMap[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T)]],
     }
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def focusable: Boolean = false
-  override def innerHeight: Int = parent.innerHeight - 3
+  override def innerHeight: Int   = parent.innerHeight - 3
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Histogram.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Histogram.scala
@@ -1,21 +1,24 @@
 package net.team2xh.onions.components.widgets
 
-import java.text.DecimalFormat
-
-import net.team2xh.onions.{Symbols, Palettes}
 import net.team2xh.onions.Themes.ColorScheme
 import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Math}
+import net.team2xh.onions.{Palettes, Symbols}
 import net.team2xh.scurses.Scurses
 
+import java.text.DecimalFormat
 import scala.Numeric.Implicits._
 
-case class Histogram[T: Numeric](parent: FramePanel, initialValues: Seq[T] = Seq[Double](),
+case class Histogram[T: Numeric](parent: FramePanel,
+                                 initialValues: Seq[T] = Seq[Double](),
                                  palette: Seq[Int] = Palettes.rainbow,
-                                 min: Option[Int] = None, max: Option[Int] = None,
-                                 labelY: String = "",  showLabels: Boolean = true,
-                                 showValues: Boolean = true)
-                                (implicit screen: Scurses) extends Widget(parent) {
+                                 min: Option[Int] = None,
+                                 max: Option[Int] = None,
+                                 labelY: String = "",
+                                 showLabels: Boolean = true,
+                                 showValues: Boolean = true
+)(implicit screen: Scurses)
+    extends Widget(parent) {
 
   val gridSize = 4
 
@@ -23,10 +26,10 @@ case class Histogram[T: Numeric](parent: FramePanel, initialValues: Seq[T] = Seq
 
   override def innerHeight: Int = parent.innerHeight - 3
 
-  val limit = 400
-  var values = initialValues
+  val limit   = 400
+  var values  = initialValues
   var counter = 0
-  val df = new DecimalFormat("#.#")
+  val df      = new DecimalFormat("#.#")
 
   def push(value: T): Unit = {
     values +:= value
@@ -41,22 +44,39 @@ case class Histogram[T: Numeric](parent: FramePanel, initialValues: Seq[T] = Seq
     val valueMax = max.getOrElse(if (values.isEmpty) 10 else Math.aBitMoreThanMax(values) + 1)
 
     val valuesLength = valueMax.toString.length max valueMin.toString.length
-    val x0 = valuesLength + (if (showLabels) 2 else 0)
-    val graphWidth = (if (showLabels) innerWidth - 3 else innerWidth - 1) - valuesLength
-    val graphHeight = innerHeight - 1
+    val x0           = valuesLength + (if (showLabels) 2 else 0)
+    val graphWidth   = (if (showLabels) innerWidth - 3 else innerWidth - 1) - valuesLength
+    val graphHeight  = innerHeight - 1
 
     // Draw grid
-    Drawing.drawGrid(x0, 0, graphWidth, graphHeight, gridSize, theme.accent1, theme.background,
-      showVertical = true, showHorizontal = true, gridOffsetX = graphWidth % 4 + (gridSize - counter))
+    Drawing.drawGrid(x0,
+                     0,
+                     graphWidth,
+                     graphHeight,
+                     gridSize,
+                     theme.accent1,
+                     theme.background,
+                     showVertical = true,
+                     showHorizontal = true,
+                     gridOffsetX = graphWidth % 4 + (gridSize - counter)
+    )
 
     // Draw axis values
-    Drawing.drawAxisValues(x0 - valuesLength, 0, graphHeight, gridSize,
-      valueMin, valueMax, theme.accent3, theme.background, horizontal = false)
+    Drawing.drawAxisValues(x0 - valuesLength,
+                           0,
+                           graphHeight,
+                           gridSize,
+                           valueMin,
+                           valueMax,
+                           theme.accent3,
+                           theme.background,
+                           horizontal = false
+    )
 
     // Draw bars
     val charHeight = (valueMax - valueMin).toDouble / graphHeight
     for (i <- 0 until ((graphWidth - 1) min values.length)) {
-      val v = values(i)
+      val v  = values(i)
       val ny = graphHeight - math.round((graphHeight * (v.toDouble - valueMin)) / (valueMax - valueMin)).toInt
 
       val color = Palettes.mapToRGB((v.toDouble - valueMin).abs, (valueMax - valueMin).abs)

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Input.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Input.scala
@@ -2,37 +2,41 @@ package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Symbols
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class Input(parent: FramePanel, var defaultText: String = "Input")
-                (implicit screen: Scurses) extends Widget(parent) {
+case class Input(parent: FramePanel, var defaultText: String = "Input")(implicit screen: Scurses)
+    extends Widget(parent) {
 
   var text: Varying[String] = ""
-  def cursorIndex = text.value.length
+  def cursorIndex           = text.value.length
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     val cursorSymbol = if (focus) Symbols.BLOCK else " "
-    val limit = innerWidth - 3
-    val t = if (cursorIndex == 0 && !focus) "<" + defaultText + ">" else text.value
-    val fg = if (cursorIndex == 0 && !focus) theme.background else theme.foreground(focus)
-    val l = t.length
-    val clippedText = Drawing.clipText(t, limit, before = true)
-    screen.put(0, 0, " " + clippedText + cursorSymbol + " " * (innerWidth - l - 3) + " ",
-      foreground = fg, background = if (focus) theme.background(focus) else theme.accent1)
+    val limit        = innerWidth - 3
+    val t            = if (cursorIndex == 0 && !focus) "<" + defaultText + ">" else text.value
+    val fg           = if (cursorIndex == 0 && !focus) theme.background else theme.foreground(focus)
+    val l            = t.length
+    val clippedText  = Drawing.clipText(t, limit, before = true)
+    screen.put(0,
+               0,
+               " " + clippedText + cursorSymbol + " " * (innerWidth - l - 3) + " ",
+               foreground = fg,
+               background = if (focus) theme.background(focus) else theme.accent1
+    )
   }
 
   override def handleKeypress(keypress: Int): Unit = {
     keypress match {
-      case Keys.BACKSPACE => if (cursorIndex > 0)
-        text := text.value.init
-      case char => text := text.value + keypress.toChar
+      case Keys.BACKSPACE =>
+        if (cursorIndex > 0)
+          text := text.value.init
+      case _ => text := text.value + keypress.toChar
     }
     needsRedraw = true
   }
 
   override def focusable: Boolean = true
-  override def innerHeight: Int = 1
+  override def innerHeight: Int   = 1
 }
-

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Label.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Label.scala
@@ -1,35 +1,38 @@
 package net.team2xh.onions.components.widgets
 
-import net.team2xh.onions.Component
 import net.team2xh.onions.Themes.ColorScheme
 import net.team2xh.onions.components.{FramePanel, Widget}
-import net.team2xh.onions.utils.{Varying, TextWrap}
-import net.team2xh.scurses.{Keys, Colors, Scurses}
+import net.team2xh.onions.utils.{TextWrap, Varying}
+import net.team2xh.scurses.{Keys, Scurses}
 
-case class Label(parent: FramePanel, text: Varying[String],
-                 alignment: Varying[Int] = TextWrap.ALIGN_LEFT, var action: () => Unit = () => {})
-                (implicit screen: Scurses) extends Widget(parent, text, alignment) {
+case class Label(parent: FramePanel,
+                 text: Varying[String],
+                 alignment: Varying[Int] = TextWrap.ALIGN_LEFT,
+                 var action: () => Unit = () => {}
+)(implicit screen: Scurses)
+    extends Widget(parent, text, alignment) {
 
-  var enabled = true
+  var enabled   = true
   def focusable = enabled
 
   var lines = Seq[String]()
 
   def drawText(foreground: Int, background: Int): Unit = {
     lines = TextWrap.wrapText(text.value, innerWidth - 1, alignment.value)
-    for ((line, i) <- lines.zipWithIndex) {
-      screen.put(0, i, " " + line + " " * (innerWidth - line.length - 1),
-        foreground = foreground, background = background)
-    }
+    for ((line, i) <- lines.zipWithIndex)
+      screen.put(0,
+                 i,
+                 " " + line + " " * (innerWidth - line.length - 1),
+                 foreground = foreground,
+                 background = background
+      )
   }
 
-  override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
+  override def redraw(focus: Boolean, theme: ColorScheme): Unit =
     drawText(theme.foreground(focus), theme.background(focus))
-  }
 
-  override def handleKeypress(keypress: Int): Unit = {
+  override def handleKeypress(keypress: Int): Unit =
     if (keypress == Keys.ENTER || keypress == Keys.SPACE) action()
-  }
 
   override def innerHeight: Int = lines.length
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Radio.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Radio.scala
@@ -1,46 +1,43 @@
 package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
 object Radio {
   def apply(parent: FramePanel, options: Seq[String])(implicit screen: Scurses): Varying[Int] = {
     val choice: Varying[Int] = 0
-    for ((option, i) <- options.zipWithIndex) {
+    for ((option, i) <- options.zipWithIndex)
       Radio(parent, option, i, choice)
-    }
     choice := 0
   }
 }
 
-private[widgets] case class Radio(parent: FramePanel, text: String, id: Int, choice: Varying[Int])
-                                 (implicit screen: Scurses) extends Widget(parent) {
+private[widgets] case class Radio(parent: FramePanel, text: String, id: Int, choice: Varying[Int])(implicit
+    screen: Scurses
+) extends Widget(parent) {
 
   def focusable = true
 
   var checked: Boolean = false
 
-  choice.subscribe(() => {
+  choice.subscribe { () =>
     checked = id == choice.value
     needsRedraw = true
-  })
+  }
 
   def drawText(foreground: Int, background: Int): Unit = {
     val line = " (%s) %s".format(if (checked) "●" else " ", Drawing.clipText(text, innerWidth - 7))
-    screen.put(0, 0, line + " " * (innerWidth - line.length - 1),
-      foreground = foreground, background = background)
+    screen.put(0, 0, line + " " * (innerWidth - line.length - 1), foreground = foreground, background = background)
   }
 
-  override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
+  override def redraw(focus: Boolean, theme: ColorScheme): Unit =
     drawText(theme.foreground(focus), theme.background(focus))
-  }
 
-  override def handleKeypress(keypress: Int): Unit = {
+  override def handleKeypress(keypress: Int): Unit =
     if (keypress == Keys.ENTER || keypress == Keys.SPACE)
-        choice := id
-  }
+      choice := id
 
   override def innerHeight: Int = 1
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
@@ -1,25 +1,24 @@
 package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{TextWrap, Varying}
 import net.team2xh.scurses.RichText.RichText
 import net.team2xh.scurses.Scurses
 
-case class RichLabel(parent: FramePanel, text: Varying[RichText])
-                    (implicit screen: Scurses) extends Widget(parent, text) {
+case class RichLabel(parent: FramePanel, text: Varying[RichText])(implicit screen: Scurses)
+    extends Widget(parent, text) {
 
   var lines = Seq[RichText]()
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     lines = TextWrap.wrapText(text.value, innerWidth - 1).toSeq
-    for ((line, i) <- lines.zipWithIndex) {
+    for ((line, i) <- lines.zipWithIndex)
       screen.putRichText(1, i, lines(i), theme.foreground, theme.background)
-    }
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def focusable: Boolean = false
-  override def innerHeight: Int = lines.length
+  override def innerHeight: Int   = lines.length
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
@@ -9,10 +9,14 @@ import net.team2xh.scurses.Scurses
 import scala.Numeric.Implicits._
 import scala.collection.mutable
 
-case class ScatterPlot[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T)]],
-                                   labelX: String = "", labelY: String = "",
-                                   color: Int = 81, showLabels: Boolean = true)
-                                  (implicit screen: Scurses) extends Widget(parent, values) {
+case class ScatterPlot[T: Numeric](parent: FramePanel,
+                                   values: Varying[Seq[(T, T)]],
+                                   labelX: String = "",
+                                   labelY: String = "",
+                                   color: Int = 81,
+                                   showLabels: Boolean = true
+)(implicit screen: Scurses)
+    extends Widget(parent, values) {
 
   val gridSize = 4
 
@@ -25,15 +29,32 @@ case class ScatterPlot[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T
     val minY = Math.aBitLessThanMin(ys)
 
     val valuesLength = maxY.toString.length max minY.toString.length
-    val x0 = valuesLength + (if (showLabels) 2 else 0)
-    val graphWidth = (if (showLabels) innerWidth - 3 else innerWidth - 1) - valuesLength
-    val graphHeight = if (showLabels) innerHeight - 3 else innerHeight - 2
+    val x0           = valuesLength + (if (showLabels) 2 else 0)
+    val graphWidth   = (if (showLabels) innerWidth - 3 else innerWidth - 1) - valuesLength
+    val graphHeight  = if (showLabels) innerHeight - 3 else innerHeight - 2
 
     // Draw grid
-    Drawing.drawGrid(x0, 0, graphWidth, graphHeight, gridSize, theme.accent1, theme.background,
-                     showVertical = true, showHorizontal = true)
+    Drawing.drawGrid(x0,
+                     0,
+                     graphWidth,
+                     graphHeight,
+                     gridSize,
+                     theme.accent1,
+                     theme.background,
+                     showVertical = true,
+                     showHorizontal = true
+    )
     // Draw axis values
-    Drawing.drawAxisValues(x0 - valuesLength, 0, graphHeight, gridSize, minY, maxY, theme.accent3, theme.background, horizontal = false)
+    Drawing.drawAxisValues(x0 - valuesLength,
+                           0,
+                           graphHeight,
+                           gridSize,
+                           minY,
+                           maxY,
+                           theme.accent3,
+                           theme.background,
+                           horizontal = false
+    )
     Drawing.drawAxisValues(x0, graphHeight + 1, graphWidth, gridSize, minX, maxX, theme.accent3, theme.background)
 
     // Draw labels
@@ -42,12 +63,12 @@ case class ScatterPlot[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T
     }
 
     // Prepare values (we use half vertical resolution)
-    val points = mutable.ArrayDeque.fill[Int](graphWidth+1, graphHeight+1)(0)
+    val points     = mutable.ArrayDeque.fill[Int](graphWidth + 1, graphHeight + 1)(0)
     val charHeight = (maxY - minY).toDouble / graphHeight
     for (value <- values.value) {
-      val nx = math.round((graphWidth * (value._1.toDouble - minX)) / (maxX - minX)).toInt
-      val ny = graphHeight - math.round((graphHeight * (value._2.toDouble - minY)) / (maxY - minY)).toInt
-      val point = points(nx)(ny)
+      val nx      = math.round((graphWidth * (value._1.toDouble - minX)) / (maxX - minX)).toInt
+      val ny      = graphHeight - math.round((graphHeight * (value._2.toDouble - minY)) / (maxY - minY)).toInt
+      val point   = points(nx)(ny)
       val isLower = if ((math.round(value._2.toDouble).toInt % charHeight) < (charHeight / 2.0)) 1 else 2
       points(nx).update(ny, point | isLower)
     }
@@ -65,8 +86,8 @@ case class ScatterPlot[T: Numeric](parent: FramePanel, values: Varying[Seq[(T, T
     }
   }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def focusable: Boolean = false
-  override def innerHeight: Int = parent.innerHeight - 3
+  override def innerHeight: Int   = parent.innerHeight - 3
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Separator.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Separator.scala
@@ -2,25 +2,22 @@ package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Symbols
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
+import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.scurses.Scurses
 
 object Separator {
-  def apply(parent: FramePanel, symbol: String = Symbols.SH)(implicit screen: Scurses) = {
+  def apply(parent: FramePanel, symbol: String = Symbols.SH)(implicit screen: Scurses) =
     new Separator(parent, symbol)
-  }
 }
 
-class Separator(parent: FramePanel, symbol: String = Symbols.SH)
-               (implicit screen: Scurses) extends Widget(parent) {
+class Separator(parent: FramePanel, symbol: String = Symbols.SH)(implicit screen: Scurses) extends Widget(parent) {
 
   val focusable = false
 
-  override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
+  override def redraw(focus: Boolean, theme: ColorScheme): Unit =
     screen.put(0, 0, symbol * innerWidth, foreground = theme.accent3, background = theme.background)
-  }
 
-  override def handleKeypress(keypress: Int): Unit = { }
+  override def handleKeypress(keypress: Int): Unit = {}
 
   override def innerHeight: Int = 1
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/SevenSegment.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/SevenSegment.scala
@@ -5,14 +5,15 @@ import net.team2xh.onions.components.widgets.SevenSegment.{empty, symbols}
 import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.{Colors, Scurses}
 
-case class SevenSegment(parent: FramePanel, text: Varying[String])
-                       (implicit screen: Scurses) extends FontMapper(parent, empty, symbols, text) {
+case class SevenSegment(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
+    extends FontMapper(parent, empty, symbols, text) {
 
   color := Colors.BRIGHT_GREEN
 }
 
 object SevenSegment {
   var empty = Seq("", "", "")
+  // format: off
   val symbols = Map(
     'a' -> Seq(
       " _  ",
@@ -175,4 +176,5 @@ object SevenSegment {
       " -  ",
       "    ")
   )
+  // format: on
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Slider.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Slider.scala
@@ -2,18 +2,18 @@ package net.team2xh.onions.components.widgets
 
 import net.team2xh.onions.Symbols
 import net.team2xh.onions.Themes.ColorScheme
-import net.team2xh.onions.components.{Widget, FramePanel}
-import net.team2xh.onions.utils.{Drawing, Varying}
+import net.team2xh.onions.components.{FramePanel, Widget}
+import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)
-                 (var currentValue: Varying[Int] = minValue)
-                 (implicit screen: Scurses) extends Widget(parent, minValue) {
+case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)(var currentValue: Varying[Int] = minValue)(implicit
+    screen: Scurses
+) extends Widget(parent, minValue) {
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {
     val width = innerWidth - 2
-    val v = currentValue.value
-    val nx = math.round((width.toDouble * (v - minValue)) / (maxValue - minValue)).toInt
+    val v     = currentValue.value
+    val nx    = math.round((width.toDouble * (v - minValue)) / (maxValue - minValue)).toInt
     val knob =
       if (nx == 0)
         Symbols.SV + " " + v + " " + Symbols.SV_TO_SR
@@ -22,10 +22,14 @@ case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)
       else
         Symbols.SV_TO_SL + " " + v + " " + Symbols.SV_TO_SR
 
-    val left = ((width - knob.length) * nx) / width
+    val left  = ((width - knob.length) * nx) / width
     val right = width - knob.length - left
-    screen.put(0, 0, " " + Symbols.SH * left + knob + Symbols.SH * right + " ",
-               theme.foreground(focus), theme.background(focus))
+    screen.put(0,
+               0,
+               " " + Symbols.SH * left + knob + Symbols.SH * right + " ",
+               theme.foreground(focus),
+               theme.background(focus)
+    )
   }
 
   override def handleKeypress(keypress: Int): Unit = {
@@ -38,5 +42,5 @@ case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)
   }
 
   override def focusable: Boolean = true
-  override def innerHeight: Int = 1
+  override def innerHeight: Int   = 1
 }

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Spacer.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Spacer.scala
@@ -3,4 +3,4 @@ package net.team2xh.onions.components.widgets
 import net.team2xh.onions.components.FramePanel
 import net.team2xh.scurses.Scurses
 
-case class Spacer(parent: FramePanel)(implicit screen: Scurses) extends Separator(parent, " ") { }
+case class Spacer(parent: FramePanel)(implicit screen: Scurses) extends Separator(parent, " ") {}

--- a/onions/src/main/scala/net/team2xh/onions/examples/ExampleUI.scala
+++ b/onions/src/main/scala/net/team2xh/onions/examples/ExampleUI.scala
@@ -1,25 +1,23 @@
 package net.team2xh.onions.examples
 
-import java.util.{TimerTask, Timer}
-
-import net.team2xh.onions.{Palettes, Themes}
 import net.team2xh.onions.components.Frame
 import net.team2xh.onions.components.widgets._
-import net.team2xh.onions.utils.{Varying, Lorem, TextWrap}
-import net.team2xh.scurses.{Colors, Scurses}
+import net.team2xh.onions.utils.{Lorem, TextWrap, Varying}
+import net.team2xh.onions.{Palettes, Themes}
 import net.team2xh.scurses.RichText._
+import net.team2xh.scurses.{Colors, Scurses}
 
+import java.util.{Timer, TimerTask}
 import scala.util.Random
 
 object ExampleUI extends App {
 
   val clockTimer = new Timer()
-  val r = Random
-  
+  val r          = Random
+
   // Fake data for plots
-  val values_1d_1 = Seq(15.7, 11.2, 2.4, 20.7, 8.2, 7.1, 4.4)
-  val values_1d_2 = Seq(15, -11, -2, 20, -8, 7, 4,
-                        10, 2, 13, -5, -8, 3, -15)
+  val values_1d_1                           = Seq(15.7, 11.2, 2.4, 20.7, 8.2, 7.1, 4.4)
+  val values_1d_2                           = Seq(15, -11, -2, 20, -8, 7, 4, 10, 2, 13, -5, -8, 3, -15)
   var values_2d_1: Varying[Seq[(Int, Int)]] = Seq()
   def generateData(): Unit =
     values_2d_1 := (1 to 50) map (i => {
@@ -35,18 +33,17 @@ object ExampleUI extends App {
 
   Scurses { implicit screen =>
     implicit val debug = true
-    val frame = Frame(title = Some("Example Onions UI - Powered by Scurses"),
-                      debug = true, theme = Themes.default)
+    val frame          = Frame(title = Some("Example Onions UI - Powered by Scurses"), debug = true, theme = Themes.default)
 
     val colA = frame.panel
     val colB = colA.splitRight
     val colC = colB.splitRight
 
-    val colB2 = colB.splitDown
-    val colB3 = colB2.splitDown
-    val colB3B = colB3.splitRight
+    val colB2   = colB.splitDown
+    val colB3   = colB2.splitDown
+    val colB3B  = colB3.splitRight
     val colB3B2 = colB3B.splitDown
-    val colC2 = colC.splitDown
+    val colC2   = colC.splitDown
 
     colA.title = "Labels"
     Label(colA, "Left-aligned text: ")
@@ -65,13 +62,16 @@ object ExampleUI extends App {
     Separator(colA)
     Label(colA, Lorem.Ipsum, TextWrap.CENTER)
     Separator(colA)
-    RichLabel(colA, r"[b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] ")
+    RichLabel(
+      colA,
+      r"[b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] [b]Supports[/b] [u]rich[/u] [fg:#3366cc]text[/fg]! [bl]nice[/bl] "
+    )
 //    RichLabel(colA, r"${Lorem.Ipsum}")
 
     colB.title = "Misc. widgets"
     Label(colB, "Enter your name here:")
     val input = Input(colB, "Name")
-    val big = BigText(colB, Varying.from(input.text, "Your name", s => s"$s"))
+    val big   = BigText(colB, Varying.from(input.text, "Your name", s => s"$s"))
     Separator(colB)
     val radio = Radio(colB, Seq("Default", "Red", "Green", "Blue"))
     radio.subscribe { () =>
@@ -93,17 +93,17 @@ object ExampleUI extends App {
 
     Label(colB3, "Choose a theme:")
     val radio2 = Radio(colB3, Seq("Default", "Light", "MS-DOS"))
-    radio2.subscribe(() => {
+    radio2.subscribe { () =>
       frame.theme := (radio2.value match {
         case 0 => Themes.default
         case 1 => Themes.light
         case 2 => Themes.MSDOS
       })
-    })
+    }
     Separator(colB3)
     Label(colB3, "Debug mode:")
     val radio3 = Radio(colB3, Seq("On", "Off"))
-    radio3.subscribe{ () =>
+    radio3.subscribe { () =>
       frame.debug := (radio3.value match {
         case 0 => true
         case 1 => false
@@ -118,11 +118,21 @@ object ExampleUI extends App {
     colC.addTab()
     val hm2 = HeatMap(colC, values_2d_2, "Price", "Popularity")
     colC.addTab()
-    val bars = BarChart(colC, values_1d_1, labels = Lorem.Ipsum.split(' '),
-                        palette = Palettes.rainbow, min = Some(0), max = Some(26))
+    val bars = BarChart(colC,
+                        values_1d_1,
+                        labels = Lorem.Ipsum.split(' '),
+                        palette = Palettes.rainbow,
+                        min = Some(0),
+                        max = Some(26)
+    )
     colC.addTab()
-    val bars2 = BarChart(colC, values_1d_2, labels = Lorem.Ipsum.split(' '),
-      palette = Palettes.default, min = Some(-18), max = Some(26))
+    val bars2 = BarChart(colC,
+                         values_1d_2,
+                         labels = Lorem.Ipsum.split(' '),
+                         palette = Palettes.default,
+                         min = Some(-18),
+                         max = Some(26)
+    )
     colC.showTab(3)
 
     colB2.title = "Histogram"
@@ -146,20 +156,24 @@ object ExampleUI extends App {
 
     var hValue = 0.0
 
-    clockTimer.scheduleAtFixedRate(new TimerTask {
-      var s = 1
-      override def run(): Unit = {
-        val column = if (s % 2 == 0) ":" else " "
-        ss.text := "%02d%s%02d".format(s / 60, column, s % 60)
-        bars.values := values_1d_1.map(n => n + r.nextDouble()*4 - 2)
-        bars2.values := values_1d_2.map(n => n + r.nextInt(5) - 2)
-        val direction = 0.8 * math.sin(s/7.0)
-        hValue = ((hValue + direction + 0.4 * r.nextGaussian()) min 10) max 0
-        h.push(hValue)
-        s += 1
-        frame.redraw()
-      }
-    }, 1000, 1000)
+    clockTimer.scheduleAtFixedRate(
+      new TimerTask {
+        var s = 1
+        override def run(): Unit = {
+          val column = if (s % 2 == 0) ":" else " "
+          ss.text      := "%02d%s%02d".format(s / 60, column, s % 60)
+          bars.values  := values_1d_1.map(n => n + r.nextDouble() * 4 - 2)
+          bars2.values := values_1d_2.map(n => n + r.nextInt(5) - 2)
+          val direction = 0.8 * math.sin(s / 7.0)
+          hValue = ((hValue + direction + 0.4 * r.nextGaussian()) min 10) max 0
+          h.push(hValue)
+          s += 1
+          frame.redraw()
+        }
+      },
+      1000,
+      1000
+    )
     frame.show()
   }
 

--- a/onions/src/main/scala/net/team2xh/onions/utils/Drawing.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/Drawing.scala
@@ -6,51 +6,69 @@ import net.team2xh.scurses.Scurses
 
 object Drawing {
 
-  def drawAxisLabels(x0: Int, graphWidth: Int, graphHeight: Int,
-                     labelX: String = "", labelY: String = "", theme: ColorScheme)
-                    (implicit screen: Scurses): Unit = {
+  def drawAxisLabels(x0: Int,
+                     graphWidth: Int,
+                     graphHeight: Int,
+                     labelX: String = "",
+                     labelY: String = "",
+                     theme: ColorScheme
+  )(implicit screen: Scurses): Unit = {
 
     if (labelX != "") {
-      val lX = if (labelX.length > graphWidth) labelX.substring(0, graphWidth - 3) + "..."
-               else labelX
+      val lX =
+        if (labelX.length > graphWidth) labelX.substring(0, graphWidth - 3) + "..."
+        else labelX
       screen.put(x0 + (graphWidth - lX.length) / 2, graphHeight + 2, lX, theme.accent3, theme.background)
     }
     if (labelY != "") {
-      val lY = if (labelY.length > graphHeight) labelY.substring(0, graphHeight - 3) + "..."
-               else labelY
+      val lY =
+        if (labelY.length > graphHeight) labelY.substring(0, graphHeight - 3) + "..."
+        else labelY
       val y0 = (graphHeight - lY.length) / 2
-      for ((char, y) <- lY.zipWithIndex) {
+      for ((char, y) <- lY.zipWithIndex)
         screen.put(0, y0 + y, "" + char, theme.accent3, theme.background)
-      }
     }
   }
 
-  def drawAxisValues(x0: Int, y0: Int, length: Int, gridSize: Int,
-                     valueMin: Int, valueMax: Int,
-                     fg: Int, bg: Int, horizontal: Boolean = true)
-                    (implicit screen: Scurses): Unit = {
+  def drawAxisValues(x0: Int,
+                     y0: Int,
+                     length: Int,
+                     gridSize: Int,
+                     valueMin: Int,
+                     valueMax: Int,
+                     fg: Int,
+                     bg: Int,
+                     horizontal: Boolean = true
+  )(implicit screen: Scurses): Unit = {
 
-    val step = if (horizontal) gridSize else gridSize / 2
-    val start = (n: Int) => if (horizontal) n else length - n
-    val span = valueMax - valueMin
+    val step      = if (horizontal) gridSize else gridSize / 2
+    val start     = (n: Int) => if (horizontal) n else length - n
+    val span      = valueMax - valueMin
     val lastIndex = if (horizontal) Seq() else Seq(length)
     for (i <- (0 until length by step) ++ lastIndex) {
       val index = math.floor((start(i) * span.toDouble) / length).toInt + valueMin
-      val x1 = if (horizontal) x0 + i else x0
-      val y1 = if (horizontal) y0 else y0 + i
+      val x1    = if (horizontal) x0 + i else x0
+      val y1    = if (horizontal) y0 else y0 + i
       screen.put(x1, y1, index.toString, fg, bg)
     }
   }
 
-  def drawGrid(x0: Int, y0: Int, w: Int, h: Int, gridWidth: Int,
-               fg: Int, bg: Int, showVertical: Boolean = true,
+  def drawGrid(x0: Int,
+               y0: Int,
+               w: Int,
+               h: Int,
+               gridWidth: Int,
+               fg: Int,
+               bg: Int,
+               showVertical: Boolean = true,
                showHorizontal: Boolean = true,
-               gridOffsetX: Int = 0, gridOffsetY: Int = 0)
-              (implicit screen: Scurses): Unit = {
+               gridOffsetX: Int = 0,
+               gridOffsetY: Int = 0
+  )(implicit screen: Scurses): Unit = {
 
-    val gridHeight = gridWidth / 2
-    val horizontalPositions = (x0 + (gridOffsetX + gridWidth) % gridWidth until x0 + w by gridWidth).filter(_ != x0)
-    val verticalPositions = (y0 + (gridOffsetY + gridHeight) % gridHeight until y0 + h by gridHeight).filter(_ != y0)
+    val gridHeight          = gridWidth / 2
+    val horizontalPositions = (x0 + (gridOffsetX + gridWidth)  % gridWidth until x0 + w by gridWidth).filter(_ != x0)
+    val verticalPositions   = (y0 + (gridOffsetY + gridHeight) % gridHeight until y0 + h by gridHeight).filter(_ != y0)
     // Corners
     screen.put(x0, y0, Symbols.TLC_S_TO_S, fg, bg)
     screen.put(x0 + w, y0, Symbols.TRC_S_TO_S, fg, bg)
@@ -58,13 +76,13 @@ object Drawing {
     screen.put(x0, y0 + h, Symbols.BLC_S_TO_S, fg, bg)
     // Edges
     for (x <- x0 + 1 until x0 + w) {
-      val symbol = if (showVertical && horizontalPositions.contains(x)) Symbols.SH_TO_SD else Symbols.SH
+      val symbol  = if (showVertical && horizontalPositions.contains(x)) Symbols.SH_TO_SD else Symbols.SH
       val symbol2 = if (showVertical && horizontalPositions.contains(x)) Symbols.SH_TO_SU else Symbols.SH
       screen.put(x, y0, symbol, fg, bg)
       screen.put(x, y0 + h, symbol2, fg, bg)
     }
     for (y <- y0 + 1 until y0 + h) {
-      val symbol = if (showHorizontal && verticalPositions.contains(y)) Symbols.SV_TO_SR else Symbols.SV
+      val symbol  = if (showHorizontal && verticalPositions.contains(y)) Symbols.SV_TO_SR else Symbols.SV
       val symbol2 = if (showHorizontal && verticalPositions.contains(y)) Symbols.SV_TO_SL else Symbols.SV
       screen.put(x0, y, symbol, fg, bg)
       screen.put(x0 + w, y, symbol2, fg, bg)
@@ -76,20 +94,20 @@ object Drawing {
       for (x <- x0 + 1 until x0 + w; y <- verticalPositions)
         screen.put(x, y, Symbols.SH, fg, bg)
     if (showHorizontal && showVertical)
-      for (x <- horizontalPositions;
-           y <- verticalPositions)
+      for (
+        x <- horizontalPositions;
+        y <- verticalPositions
+      )
         screen.put(x, y, Symbols.SH_X_SV, fg, bg)
   }
 
   def clipText(text: String, limit: Int, before: Boolean = false) =
     if (text.length > limit) {
-      val clipped = text.substring(if (before) text.length - limit + 3 else 0,
-                                   if (before) text.length else limit - 3)
+      val clipped = text.substring(if (before) text.length - limit + 3 else 0, if (before) text.length else limit - 3)
       if (before)
         "..." + clipped
       else
         clipped + "..."
-    }
-    else text
+    } else text
 
 }

--- a/onions/src/main/scala/net/team2xh/onions/utils/Math.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/Math.scala
@@ -1,56 +1,49 @@
 package net.team2xh.onions.utils
 
+import scala.Numeric.Implicits._
 import scala.collection.mutable.ArrayBuffer
-import Numeric.Implicits._
 
 object Math {
 
-  def aBitMoreThanMax[T: Numeric](ns: Seq[T]) = {
+  def aBitMoreThanMax[T: Numeric](ns: Seq[T]) =
     ns.max.toInt + math.pow(10, math.log10(ns.max.toDouble / 10.0)).toInt
-  }
 
-  def aBitLessThanMin[T: Numeric](ns: Seq[T]) = {
+  def aBitLessThanMin[T: Numeric](ns: Seq[T]) =
     ns.min.toInt - math.pow(10, math.log10(ns.min.toDouble.abs / 10.0)).toInt
-  }
 
   val `√2π` = math.sqrt(2 * math.Pi)
 
   def gauss1d(x: Double, σ: Double, μ: Double = 0.0): Double = {
     val a = 1 / (σ * `√2π`)
-    a * math.exp(-(x - μ)*(x - μ) / (2*σ*σ))
+    a * math.exp(-(x - μ) * (x - μ) / (2 * σ * σ))
   }
 
-  def gauss2d(x: Double, y: Double, a: Double, σx: Double, σy: Double, μx: Double = 0.0, μy: Double = 0.0): Double = {
-    a * math.exp(-((x - μx)*(x - μx) / (2*σx*σx) + (y - μy)*(y - μy) / (2*σy*σy)))
-  }
+  def gauss2d(x: Double, y: Double, a: Double, σx: Double, σy: Double, μx: Double = 0.0, μy: Double = 0.0): Double =
+    a * math.exp(-((x - μx) * (x - μx) / (2 * σx * σx) + (y - μy) * (y - μy) / (2 * σy * σy)))
 
-  def simpleGauss1d(x: Double, σ: Double): Double = {
-    math.exp(-x*x / (2*σ*σ))
-  }
+  def simpleGauss1d(x: Double, σ: Double): Double =
+    math.exp(-x * x / (2 * σ * σ))
 
-  def simpleGauss2d(x: Double, y: Double, σ: Double): Double = {
-    math.exp(-(x*x / (2*σ*σ) + y*y / (2*σ*σ)))
-  }
+  def simpleGauss2d(x: Double, y: Double, σ: Double): Double =
+    math.exp(-(x * x / (2 * σ * σ) + y * y / (2 * σ * σ)))
 
   case class GaussianArray(width: Int, height: Int, kernelRadius: Int = 1) {
 
     val array = ArrayBuffer.fill[Double](width, height)(0.0)
 
-    def add(x0: Int, y0: Int): Unit = {
+    def add(x0: Int, y0: Int): Unit =
       for (x <- -kernelRadius to kernelRadius; y <- -kernelRadius to kernelRadius) {
         val xx = x0 + x
         val yy = y0 + y
         if (xx >= 0 && xx < width && yy >= 0 && yy < height) {
-          val v = simpleGauss2d(x, y, kernelRadius / 2.0)
+          val v   = simpleGauss2d(x, y, kernelRadius / 2.0)
           val old = array(xx)(yy)
           array(xx).update(yy, old + v)
         }
       }
-    }
 
-    def apply(x0: Int, y0: Int): Double = {
+    def apply(x0: Int, y0: Int): Double =
       array(x0)(y0)
-    }
 
     def min: Double = array.map(_.min).min
 

--- a/onions/src/main/scala/net/team2xh/onions/utils/TextWrap.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/TextWrap.scala
@@ -1,9 +1,8 @@
 package net.team2xh.onions.utils
 
-import java.util.StringTokenizer
-
 import net.team2xh.scurses.RichText._
 
+import java.util.StringTokenizer
 import scala.collection.mutable
 
 object TextWrap {
@@ -13,18 +12,17 @@ object TextWrap {
   val CENTER      = 2
   val JUSTIFY     = 3
 
-  def wrapText(richText: RichText, width: Int): mutable.Seq[RichText] = {
+  def wrapText(richText: RichText, width: Int): mutable.Seq[RichText] =
     wrapText(richText, width, ALIGN_LEFT)
-  }
 
   def wrapText(richText: RichText, width: Int, alignment: Int): mutable.Seq[RichText] = {
     val instructions = richText.instructions.iterator
-    var spaceLeft = width
+    var spaceLeft    = width
 
-    var activeAttributes = mutable.Map[Attribute, Instruction]()
-    var lines = mutable.ArrayDeque[(List[Instruction], Int)]()
-    var line = mutable.ArrayDeque[Instruction]()
-    var chunk = ""
+    val activeAttributes = mutable.Map[Attribute, Instruction]()
+    val lines            = mutable.ArrayDeque[(List[Instruction], Int)]()
+    var line             = mutable.ArrayDeque[Instruction]()
+    var chunk            = ""
 
     while (instructions.hasNext) {
       val instruction = instructions.next()
@@ -36,7 +34,7 @@ object TextWrap {
           attribute match {
             case Foreground => activeAttributes.filterNot { case (k, v) => k.isInstanceOf[Foreground] }
             case Background => activeAttributes.filterNot { case (k, v) => k.isInstanceOf[Background] }
-            case _ => activeAttributes -= attribute
+            case _          => activeAttributes -= attribute
           }
           line += instruction
         case ResetAttributes =>
@@ -73,7 +71,7 @@ object TextWrap {
     var spaceLeft = width
 
     val lines = mutable.ArrayDeque[(List[String], Int)]()
-    var line = mutable.ArrayDeque[String]()
+    var line  = mutable.ArrayDeque[String]()
 
     while (tokenizer.hasMoreTokens) {
       val word = tokenizer.nextToken
@@ -89,31 +87,33 @@ object TextWrap {
     }
     lines += ((line.toList, spaceLeft))
     alignment match {
-      case ALIGN_LEFT => lines.map(_._1.mkString(" ")).toSeq
+      case ALIGN_LEFT  => lines.map(_._1.mkString(" ")).toSeq
       case ALIGN_RIGHT => lines.map { case (l, s) => " " * s + l.mkString(" ") }.toSeq
-      case CENTER => lines.map { case (l, s) =>
-        val s1 = s / 2
-        val s2 = s - s1
-        " " * s1 + l.mkString(" ") + " " * s2
-      }.toSeq
-      case JUSTIFY => lines.zipWithIndex.map { case ((l, s), i) =>
-        if (l.length == 1) {
-          l.head
-        } else if (i == lines.length - 1) {
-          l.mkString(" ")
-        } else {
-          val spaceWidth = s / (l.length - 1)
-          var rest = s - (spaceWidth * (l.length - 1))
-          l.zipWithIndex.map { case (word, j) =>
-            if (rest > 0) {
-              rest -= 1
-              word + " " * (spaceWidth + 2)
-            } else if (j == l.length - 1) {
-              word
-            } else word + " " * (spaceWidth + 1)
-          }.mkString
-        }
-      }.toSeq
+      case CENTER =>
+        lines.map { case (l, s) =>
+          val s1 = s / 2
+          val s2 = s - s1
+          " " * s1 + l.mkString(" ") + " " * s2
+        }.toSeq
+      case JUSTIFY =>
+        lines.zipWithIndex.map { case ((l, s), i) =>
+          if (l.length == 1) {
+            l.head
+          } else if (i == lines.length - 1) {
+            l.mkString(" ")
+          } else {
+            val spaceWidth = s / (l.length - 1)
+            var rest       = s - (spaceWidth * (l.length - 1))
+            l.zipWithIndex.map { case (word, j) =>
+              if (rest > 0) {
+                rest -= 1
+                word + " " * (spaceWidth + 2)
+              } else if (j == l.length - 1) {
+                word
+              } else word + " " * (spaceWidth + 1)
+            }.mkString
+          }
+        }.toSeq
     }
   }
 

--- a/onions/src/main/scala/net/team2xh/onions/utils/Varying.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/Varying.scala
@@ -6,24 +6,24 @@ import net.team2xh.scurses.RichText.RichText
 import scala.language.implicitConversions
 
 object Varying {
-  implicit def stringToVarying(value: String): Varying[String] = new Varying(value)
-  implicit def richTextToVarying(value: RichText): Varying[RichText] = new Varying(value)
-  implicit def numericToVarying[T: Numeric](value: T): Varying[T] = new Varying(value)
-  implicit def booleanToVarying(value: Boolean): Varying[Boolean] = new Varying(value)
-  implicit def colorSchemeToVarying(value: ColorScheme): Varying[ColorScheme] = new Varying(value)
-  implicit def seqNumericToVarying[T: Numeric](values: Seq[T]): Varying[Seq[T]] = new Varying(values)
+  implicit def stringToVarying(value: String): Varying[String]                                  = new Varying(value)
+  implicit def richTextToVarying(value: RichText): Varying[RichText]                            = new Varying(value)
+  implicit def numericToVarying[T: Numeric](value: T): Varying[T]                               = new Varying(value)
+  implicit def booleanToVarying(value: Boolean): Varying[Boolean]                               = new Varying(value)
+  implicit def colorSchemeToVarying(value: ColorScheme): Varying[ColorScheme]                   = new Varying(value)
+  implicit def seqNumericToVarying[T: Numeric](values: Seq[T]): Varying[Seq[T]]                 = new Varying(values)
   implicit def seqTuple2NumericToVarying[T: Numeric](values: Seq[(T, T)]): Varying[Seq[(T, T)]] = new Varying(values)
 
   def from[T](varying: Varying[T], initial: T, result: T => T): Varying[T] = new Varying[T](initial) {
-    varying.subscribe(() => {
+    varying.subscribe { () =>
       this := result(varying.value)
-    })
+    }
   }
 }
 
 class Varying[T](initialValue: T) {
 
-  var storedValue = initialValue
+  var storedValue                         = initialValue
   private var callbacks: List[() => Unit] = Nil
 
   def :=(newValue: T): Varying[T] = {
@@ -32,9 +32,8 @@ class Varying[T](initialValue: T) {
     this
   }
 
-  def subscribe(callback: () => Unit): Unit = {
+  def subscribe(callback: () => Unit): Unit =
     callbacks ::= callback
-  }
 
   def value = storedValue
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"       % "3.9.7")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"            % "2.1.2")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.12.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.4.3")
 
 logLevel := Level.Warn

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.12.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
 logLevel := Level.Warn

--- a/scurses/src/main/scala/net/team2xh/scurses/Colors.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/Colors.scala
@@ -4,16 +4,16 @@ import java.awt.Color
 
 object Colors {
   // Color codes
-  val DIM_BLACK      =  0
-  val DIM_RED        =  1
-  val DIM_GREEN      =  2
-  val DIM_YELLOW     =  3
-  val DIM_BLUE       =  4
-  val DIM_MAGENTA    =  5
-  val DIM_CYAN       =  6
-  val DIM_WHITE      =  7
-  val BRIGHT_BLACK   =  8
-  val BRIGHT_RED     =  9
+  val DIM_BLACK      = 0
+  val DIM_RED        = 1
+  val DIM_GREEN      = 2
+  val DIM_YELLOW     = 3
+  val DIM_BLUE       = 4
+  val DIM_MAGENTA    = 5
+  val DIM_CYAN       = 6
+  val DIM_WHITE      = 7
+  val BRIGHT_BLACK   = 8
+  val BRIGHT_RED     = 9
   val BRIGHT_GREEN   = 10
   val BRIGHT_YELLOW  = 11
   val BRIGHT_BLUE    = 12
@@ -49,9 +49,11 @@ object Colors {
     val h = if (hex(0) == '#') hex.tail else hex
     (Integer.parseInt("" + h(0) + h(1), 16),
      Integer.parseInt("" + h(2) + h(3), 16),
-     Integer.parseInt("" + h(4) + h(5), 16))
+     Integer.parseInt("" + h(4) + h(5), 16)
+    )
   }
 
+  // format: off
   private val xtermHex = Seq(
     "000000", "800000", "008000", "808000", "000080", "800080", "008080", "c0c0c0",
     "808080", "ff0000", "00ff00", "ffff00", "0000ff", "ff00ff", "00ffff", "ffffff",
@@ -85,6 +87,7 @@ object Colors {
     "080808", "121212", "1c1c1c", "262626", "303030", "3a3a3a", "444444", "4e4e4e",
     "585858", "606060", "666666", "767676", "808080", "8a8a8a", "949494", "9e9e9e",
     "a8a8a8", "b2b2b2", "bcbcbc", "c6c6c6", "d0d0d0", "dadada", "e4e4e4", "eeeeee")
+  // format: on
 
   private val xtermRGB = xtermHex map hexToRGB
 
@@ -92,7 +95,7 @@ object Colors {
     val x = a._1 - b._1
     val y = a._2 - b._2
     val z = a._3 - b._3
-    math.sqrt(x*x + y*y + z*z)
+    math.sqrt(x * x + y * y + z * z)
   }
 
 }

--- a/scurses/src/main/scala/net/team2xh/scurses/EscapeCodes.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/EscapeCodes.scala
@@ -2,13 +2,12 @@ package net.team2xh.scurses
 
 import java.io.OutputStream
 
-/**
- * ANSI Escape Codes manager
- * Reference: http://www.vt100.net/docs/vt510-rm/contents
- *            http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
- *
- * @param out Terminal output stream
- */
+/** ANSI Escape Codes manager
+  * Reference: http://www.vt100.net/docs/vt510-rm/contents
+  *            http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+  *
+  * @param out Terminal output stream
+  */
 class EscapeCodes(out: OutputStream) {
 
   // Output an Escape Sequence
@@ -24,72 +23,111 @@ class EscapeCodes(out: OutputStream) {
   private def CSI(mode: Char, command: Char) { CSI(s"$mode$command") }
   private def CSI(mode: Char, n: Int, command: Char) { CSI(s"$mode$n;$command") }
 
-  /* DSR */ def status() { CSI(5, 'n') }
+  /* DSR */
+  def status() { CSI(5, 'n') }
 
   // Cursor movement
-  /* CUU */ def moveUp   (n: Int = 1) { CSI(n, 'A') }
-  /* CUD */ def moveDown (n: Int = 1) { CSI(n, 'B') }
-  /* CUF */ def moveRight(n: Int = 1) { CSI(n, 'C') }
-  /* CUB */ def moveLeft (n: Int = 1) { CSI(n, 'D') }
-  /* CUP */ def move(y: Int, x: Int)  { CSI(x + 1, y + 1, 'H') }
+  /* CUU */
+  def moveUp(n: Int = 1) { CSI(n, 'A') }
+  /* CUD */
+  def moveDown(n: Int = 1) { CSI(n, 'B') }
+  /* CUF */
+  def moveRight(n: Int = 1) { CSI(n, 'C') }
+  /* CUB */
+  def moveLeft(n: Int = 1) { CSI(n, 'D') }
+  /* CUP */
+  def move(y: Int, x: Int) { CSI(x + 1, y + 1, 'H') }
 
   // Cursor management
-  /* DECTCEM */ def hideCursor()    { CSI('?', 25, 'l') }
-  /* DECTCEM */ def showCursor()    { CSI('?', 25, 'h') }
-  /*  DECSC  */ def saveCursor()    { ESC('7') }
-  /*  DECRC  */ def restoreCursor() { ESC('8') }
+  /* DECTCEM */
+  def hideCursor() { CSI('?', 25, 'l') }
+  /* DECTCEM */
+  def showCursor() { CSI('?', 25, 'h') }
+  /*  DECSC  */
+  def saveCursor() { ESC('7') }
+  /*  DECRC  */
+  def restoreCursor() { ESC('8') }
   // Somehow this fails when the window has a height of 30-39:
-  /*   CPR   */ def cursorPosition() = { val r = getReport(() => CSI(6, 'n'), 2, 'R'); (r(1), r(0)) }
+  /*   CPR   */
+  def cursorPosition() = { val r = getReport(() => CSI(6, 'n'), 2, 'R'); (r(1), r(0)) }
 
   // Screen management
-  /*   ED   */ def clear()                      { CSI(2, 'J') }
-  /* DECSET */ def alternateBuffer()            { CSI('?', 47, 'h') }
-  /* DECRST */ def normalBuffer()               { CSI('?', 47, 'l') }
-  /*   RIS  */ def fullReset()                  { ESC('c') }
-  /* dtterm */ def resizeScreen(w: Int, h: Int) { CSI(8, w, h, 't') }
-  /* dtterm */ def screenSize() = { val r = getReport(() => CSI(18, 't'), 3, 't'); (r(2), r(1)) }
+  /*   ED   */
+  def clear() { CSI(2, 'J') }
+  /* DECSET */
+  def alternateBuffer() { CSI('?', 47, 'h') }
+  /* DECRST */
+  def normalBuffer() { CSI('?', 47, 'l') }
+  /*   RIS  */
+  def fullReset() { ESC('c') }
+  /* dtterm */
+  def resizeScreen(w: Int, h: Int) { CSI(8, w, h, 't') }
+  /* dtterm */
+  def screenSize() = { val r = getReport(() => CSI(18, 't'), 3, 't'); (r(2), r(1)) }
 
   // Window management
-  /* dtterm */ def unminimizeWindow()           { CSI(1, 't')}
-  /* dtterm */ def minimizeWindow()             { CSI(2, 't')}
-  /* dtterm */ def moveWindow(x: Int, y: Int)   { CSI(3, x, y, 't') }
-  /* dtterm */ def resizeWindow(w: Int, h: Int) { CSI(4, w, h, 't') }
-  /* dtterm */ def moveToTop()                  { CSI(5, 't') }
-  /* dtterm */ def moveToBottom()               { CSI(6, 't') }
-  /* dtterm */ def restoreWindow()              { CSI(9, 0, 't')}
-  /* dtterm */ def maximizeWindow()             { CSI(9, 1, 't')}
-  /* dtterm */ def windowPosition() = { val r = getReport(() => CSI(13, 't'), 3, 't'); (r(2), r(1)) }
-  /* dtterm */ def windowSize()     = { val r = getReport(() => CSI(14, 't'), 3, 't'); (r(2), r(1)) }
+  /* dtterm */
+  def unminimizeWindow() { CSI(1, 't') }
+  /* dtterm */
+  def minimizeWindow() { CSI(2, 't') }
+  /* dtterm */
+  def moveWindow(x: Int, y: Int) { CSI(3, x, y, 't') }
+  /* dtterm */
+  def resizeWindow(w: Int, h: Int) { CSI(4, w, h, 't') }
+  /* dtterm */
+  def moveToTop() { CSI(5, 't') }
+  /* dtterm */
+  def moveToBottom() { CSI(6, 't') }
+  /* dtterm */
+  def restoreWindow() { CSI(9, 0, 't') }
+  /* dtterm */
+  def maximizeWindow() { CSI(9, 1, 't') }
+  /* dtterm */
+  def windowPosition() = { val r = getReport(() => CSI(13, 't'), 3, 't'); (r(2), r(1)) }
+  /* dtterm */
+  def windowSize() = { val r = getReport(() => CSI(14, 't'), 3, 't'); (r(2), r(1)) }
 
   // Color management
-  /* ISO-8613-3 */ def setForeground(color: Int) { CSI(38, 5, color, 'm') }
-  /* ISO-8613-3 */ def setBackground(color: Int) { CSI(48, 5, color, 'm') }
-  /*     SGR    */ def startBold()      { CSI(1, 'm') }
-  /*     SGR    */ def startUnderline() { CSI(4, 'm') }
-  /*     SGR    */ def startBlink()     { CSI(5, 'm') }
-  /*     SGR    */ def startReverse()   { CSI(7, 'm') }
-  /*     SGR    */ def stopBold()       { CSI(22, 'm') }
-  /*     SGR    */ def stopUnderline()  { CSI(24, 'm') }
-  /*     SGR    */ def stopBlink()      { CSI(25, 'm') }
-  /*     SGR    */ def stopReverse()    { CSI(27, 'm') }
-  /*     SGR    */ def stopForeground() { CSI(39, 'm')}
-  /*     SGR    */ def stopBackground() { CSI(49, 'm')}
-  /*     SGR    */ def resetColors()    { CSI(0, 'm') }
+  /* ISO-8613-3 */
+  def setForeground(color: Int) { CSI(38, 5, color, 'm') }
+  /* ISO-8613-3 */
+  def setBackground(color: Int) { CSI(48, 5, color, 'm') }
+  /*     SGR    */
+  def startBold() { CSI(1, 'm') }
+  /*     SGR    */
+  def startUnderline() { CSI(4, 'm') }
+  /*     SGR    */
+  def startBlink() { CSI(5, 'm') }
+  /*     SGR    */
+  def startReverse() { CSI(7, 'm') }
+  /*     SGR    */
+  def stopBold() { CSI(22, 'm') }
+  /*     SGR    */
+  def stopUnderline() { CSI(24, 'm') }
+  /*     SGR    */
+  def stopBlink() { CSI(25, 'm') }
+  /*     SGR    */
+  def stopReverse() { CSI(27, 'm') }
+  /*     SGR    */
+  def stopForeground() { CSI(39, 'm') }
+  /*     SGR    */
+  def stopBackground() { CSI(49, 'm') }
+  /*     SGR    */
+  def resetColors() { CSI(0, 'm') }
 
-  /**
-   * Executes a request and parses the response report.
-   * Usually, they would start with a CSI but JLine seems to ignore them.
-   * @param csi        CSI to execute
-   * @param args       How many arguments are expected
-   * @param terminator Terminator character of the report
-   * @return           Sequence of parsed integers
-   */
+  /** Executes a request and parses the response report.
+    * Usually, they would start with a CSI but JLine seems to ignore them.
+    * @param csi        CSI to execute
+    * @param args       How many arguments are expected
+    * @param terminator Terminator character of the report
+    * @return           Sequence of parsed integers
+    */
   def getReport(csi: () => Unit, args: Int, terminator: Char): Array[Int] = {
     // Send the CSI
     csi()
     out.flush()
 
-    val results = Array.fill(args)("")
+    val results    = Array.fill(args)("")
     val separators = Array.fill(args - 1)(';') :+ terminator
     // Parse CSI
     System.in.read()
@@ -105,5 +143,3 @@ class EscapeCodes(out: OutputStream) {
     results.map(_.toInt)
   }
 }
-
-

--- a/scurses/src/main/scala/net/team2xh/scurses/Keys.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/Keys.scala
@@ -2,7 +2,7 @@ package net.team2xh.scurses
 
 object Keys {
 
-  val PUA = 0xE000 // Unicode private use area, safe for our own codes
+  val PUA = 0xe000 // Unicode private use area, safe for our own codes
 
   // Resize signal
   val RESIZE = PUA + 1000
@@ -24,19 +24,19 @@ object Keys {
   val SHIFT_TAB = PUA + 4
 
   def repr(key: Int): String = key match {
-    case RESIZE    => "RESIZE"
-    case CTRL_SPACE=> "CTRL+SPACE"
-    case CTRL_C    => "CTRL+C"
-    case TAB       => "⇥ "
-    case ENTER     => "↵ "
-    case ESC       => "ESC"
-    case SPACE     => "SPACE"
-    case BACKSPACE => "⇤ "
-    case UP        => "↑"
-    case DOWN      => "↓"
-    case LEFT      => "←"
-    case RIGHT     => "→"
-    case SHIFT_TAB => "⇧ +⇥ "
-    case _ => key.toChar.toString
+    case RESIZE     => "RESIZE"
+    case CTRL_SPACE => "CTRL+SPACE"
+    case CTRL_C     => "CTRL+C"
+    case TAB        => "⇥ "
+    case ENTER      => "↵ "
+    case ESC        => "ESC"
+    case SPACE      => "SPACE"
+    case BACKSPACE  => "⇤ "
+    case UP         => "↑"
+    case DOWN       => "↓"
+    case LEFT       => "←"
+    case RIGHT      => "→"
+    case SHIFT_TAB  => "⇧ +⇥ "
+    case _          => key.toChar.toString
   }
 }

--- a/scurses/src/main/scala/net/team2xh/scurses/RichText.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/RichText.scala
@@ -3,45 +3,44 @@ package net.team2xh.scurses
 import fastparse._
 import NoWhitespace._
 
-/**
- * RichText string interpolator.
- *
- * Example usage:
- *   val color = "blue"
- *   val greet = "Hello"
- *   val richText = r"[b][fg:$color]$greet[/b], World!"
- *
- * Format:
- *   [b]        Start using bold text
- *   [u]        Start underlining text
- *   [bl]       Start blinking text
- *   [r]        Start reversing foreground and background
- *   [fg:color] Start coloring the foreground with a named color (e.g. "red")
- *   [fg:id]    Same with an xterm 256-color code (0 - 256)
- *   [fg:hex]   Same with an arbitrary RGB hexadecimal color code
- *   [bg:color] Start coloring the background with a named color (e.g. "red")
- *   [bg:id]    Same with an xterm 256-color code (0 - 256)
- *   [bg:hex]   Same with an arbitrary RGB hexadecimal color code
- *
- *   [/b]       Stop using bold text
- *   [/u]       Stop underlining text
- *   [/bl]      Stop blinking text
- *   [/r]       Stop reversing foreground and background
- *   [/fg]      Stop coloring the foreground
- *   [/bg]      Stop coloring the background
- *   [/*]       Stop all
- *
- * Tags don't have to be closed
- */*/
+/** RichText string interpolator.
+  *
+  * Example usage:
+  *   val color = "blue"
+  *   val greet = "Hello"
+  *   val richText = r"[b][fg:$color]$greet[/b], World!"
+  *
+  * Format:
+  *   [b]        Start using bold text
+  *   [u]        Start underlining text
+  *   [bl]       Start blinking text
+  *   [r]        Start reversing foreground and background
+  *   [fg:color] Start coloring the foreground with a named color (e.g. "red")
+  *   [fg:id]    Same with an xterm 256-color code (0 - 256)
+  *   [fg:hex]   Same with an arbitrary RGB hexadecimal color code
+  *   [bg:color] Start coloring the background with a named color (e.g. "red")
+  *   [bg:id]    Same with an xterm 256-color code (0 - 256)
+  *   [bg:hex]   Same with an arbitrary RGB hexadecimal color code
+  *
+  *   [/b]       Stop using bold text
+  *   [/u]       Stop underlining text
+  *   [/bl]      Stop blinking text
+  *   [/r]       Stop reversing foreground and background
+  *   [/fg]      Stop coloring the foreground
+  *   [/bg]      Stop coloring the background
+  *   [&#47*]    Stop all
+  *
+  * Tags don't have to be closed
+  */
 object RichText {
 
   implicit class RichTextHelper(val sc: StringContext) extends AnyVal {
     def r(args: Any*): RichText = {
-      val input = sc.s(args: _*)
+      val input  = sc.s(args: _*)
       val result = parse(input, richText(_))
       result match {
         case Parsed.Success(rt, _) => rt
-        case _: Parsed.Failure => RichText(Text(input))
+        case _: Parsed.Failure     => RichText(Text(input))
       }
     }
   }
@@ -49,63 +48,63 @@ object RichText {
   case class RichText(instructions: Instruction*)
 
   sealed trait Instruction
-  case class Text(text: String) extends Instruction
+  case class Text(text: String)                   extends Instruction
   case class StartAttribute(attribute: Attribute) extends Instruction
-  case class StopAttribute(attribute: Attribute) extends Instruction
-  case object ResetAttributes extends Instruction
+  case class StopAttribute(attribute: Attribute)  extends Instruction
+  case object ResetAttributes                     extends Instruction
 
   sealed trait Attribute
-  case object Bold extends Attribute
-  case object Underline extends Attribute
-  case object Blink extends Attribute
-  case object Reverse extends Attribute
-  case object Foreground extends Attribute
-  case object Background extends Attribute
+  case object Bold                    extends Attribute
+  case object Underline               extends Attribute
+  case object Blink                   extends Attribute
+  case object Reverse                 extends Attribute
+  case object Foreground              extends Attribute
+  case object Background              extends Attribute
   case class Foreground(color: Color) extends Attribute
   case class Background(color: Color) extends Attribute
 
   sealed trait Color
   case class NamedColor(name: String) extends Color
-  case class IndexedColor(code: Int) extends Color
-  case class HexColor(hex: String) extends Color
+  case class IndexedColor(code: Int)  extends Color
+  case class HexColor(hex: String)    extends Color
 
-  private def letter   [_: P] = P( CharIn("a-z") )
-  private def digit    [_: P] = P( CharIn("0-9") )
-  private def hexDigit [_: P] = P( CharIn("0-9", "a-f", "A-F") )
+  private def letter[_: P]   = P(CharIn("a-z"))
+  private def digit[_: P]    = P(CharIn("0-9"))
+  private def hexDigit[_: P] = P(CharIn("0-9", "a-f", "A-F"))
 
-  private def name  [_: P] = P( letter.rep(1).! )
-  private def index [_: P] = P( digit.rep(1).! ) map (_.toInt)
-  private def hex   [_: P] = P( ("#" ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit).! )
+  private def name[_: P]  = P(letter.rep(1).!)
+  private def index[_: P] = P(digit.rep(1).!) map (_.toInt)
+  private def hex[_: P]   = P(("#" ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit ~/ hexDigit).!)
 
-  private def bold       [_: P] = P( "b" )  map (_ => Bold)
-  private def underline  [_: P] = P( "u" )  map (_ => Underline)
-  private def blink      [_: P] = P( "bl" ) map (_ => Blink)
-  private def reverse    [_: P] = P( "r" )  map (_ => Reverse)
-  private def foreground [_: P] = P( "fg" ) map (_ => Foreground)
-  private def background [_: P] = P( "bg" ) map (_ => Background)
+  private def bold[_: P]       = P("b") map (_ => Bold)
+  private def underline[_: P]  = P("u") map (_ => Underline)
+  private def blink[_: P]      = P("bl") map (_ => Blink)
+  private def reverse[_: P]    = P("r") map (_ => Reverse)
+  private def foreground[_: P] = P("fg") map (_ => Foreground)
+  private def background[_: P] = P("bg") map (_ => Background)
 
-  private def attribute [_: P] = P( underline | blink | bold | reverse | foreground | background )
+  private def attribute[_: P] = P(underline | blink | bold | reverse | foreground | background)
 
-  private def namedColor   [_: P] = P( name ) map NamedColor
-  private def indexedColor [_: P] = P( index ) map IndexedColor
-  private def hexColor     [_: P] = P( hex ) map HexColor
+  private def namedColor[_: P]   = P(name) map NamedColor
+  private def indexedColor[_: P] = P(index) map IndexedColor
+  private def hexColor[_: P]     = P(hex) map HexColor
 
-  private def color [_: P] = P( namedColor | indexedColor | hexColor )
+  private def color[_: P] = P(namedColor | indexedColor | hexColor)
 
-  private def startAttribute [_: P] = P( attribute ) map StartAttribute
-  private def beginColor [_: P] = P( ("fg" | "bg").! ~ ":" ~/ color ) map {
+  private def startAttribute[_: P] = P(attribute) map StartAttribute
+  private def beginColor[_: P] = P(("fg" | "bg").! ~ ":" ~/ color) map {
     case ("fg", aColor) => StartAttribute(Foreground(aColor))
     case (_, aColor)    => StartAttribute(Background(aColor))
   }
-  private def stop [_: P] = P( "/" ~/ ("*".! | attribute) ) map {
-    case "*" => ResetAttributes
+  private def stop[_: P] = P("/" ~/ ("*".! | attribute)) map {
+    case "*"             => ResetAttributes
     case attr: Attribute => StopAttribute(attr)
   }
 
-  private def block [_: P] = P( "[" ~/ (beginColor | startAttribute | stop) ~/ "]" )
-  private def escape [_: P] = P( "[[".! ) map (_ => Text("["))
-  private def text [_: P] = P( CharsWhile(c => c != '[').! ) map Text
+  private def block[_: P]  = P("[" ~/ (beginColor | startAttribute | stop) ~/ "]")
+  private def escape[_: P] = P("[[".!) map (_ => Text("["))
+  private def text[_: P]   = P(CharsWhile(c => c != '[').!) map Text
 
-  private def richText [_: P] = P( (text | escape | block).rep ) map (RichText(_: _*))
+  private def richText[_: P] = P((text | escape | block).rep) map (RichText(_: _*))
 
 }

--- a/scurses/src/main/scala/net/team2xh/scurses/examples/GameOfLife.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/examples/GameOfLife.scala
@@ -1,9 +1,8 @@
 package net.team2xh.scurses.examples
 
-import java.util.{Timer, TimerTask}
-
 import net.team2xh.scurses.Scurses
 
+import java.util.{Timer, TimerTask}
 import scala.util.Random
 
 case class GameOfLife(width: Int, height: Int, wrapAround: Boolean = false) {
@@ -12,35 +11,34 @@ case class GameOfLife(width: Int, height: Int, wrapAround: Boolean = false) {
 
   def field = cells
 
-  def set(x0: Int, y0: Int, value: Int = 1): Unit = {
-    cells = for (y <- 0 until height) yield for (x <- 0 until width) yield {
-      if (x == x0 && y == y0) value
-      else cells(y)(x)
-    }
-  }
+  def set(x0: Int, y0: Int, value: Int = 1): Unit =
+    cells =
+      for (y <- 0 until height)
+        yield for (x <- 0 until width)
+          yield
+            if (x == x0 && y == y0) value
+            else cells(y)(x)
 
   def glider(x0: Int, y0: Int): Unit = {
     set(x0, y0)
-    set(x0+1, y0+1)
-    set(x0-1, y0+2)
-    set(x0, y0+2)
-    set(x0+1, y0+2)
+    set(x0 + 1, y0 + 1)
+    set(x0 - 1, y0 + 2)
+    set(x0, y0 + 2)
+    set(x0 + 1, y0 + 2)
   }
 
-  def cell(x: Int, y: Int): Int = {
+  def cell(x: Int, y: Int): Int =
     if (wrapAround) {
       cells((y + height) % height)((x + width) % width)
     } else {
       if (x < 0 || y < 0 || x >= width || y >= height) 0
       else cells(y)(x)
     }
-  }
 
-  def neighbours(x: Int, y: Int): Int = {
-    cell(x-1, y-1) + cell(x, y-1) + cell(x+1, y-1) +
-      cell(x-1, y)                  + cell(x+1, y)   +
-      cell(x-1, y+1) + cell(x, y+1) + cell(x+1, y+1)
-  }
+  def neighbours(x: Int, y: Int): Int =
+    cell(x - 1, y - 1) + cell(x, y - 1) + cell(x + 1, y - 1) +
+      cell(x - 1, y) + cell(x + 1, y) +
+      cell(x - 1, y + 1) + cell(x, y + 1) + cell(x + 1, y + 1)
 
   def alive(x: Int, y: Int): Int = {
     val n = neighbours(x, y)
@@ -49,44 +47,37 @@ case class GameOfLife(width: Int, height: Int, wrapAround: Boolean = false) {
     else 0
   }
 
-  def step() = {
-    cells =
-      for (y <- 0 until height) yield {
-        for (x <- 0 until width) yield {
-          alive(x, y)
-        }
-      }
-  }
+  def step() =
+    cells = for (y <- 0 until height) yield for (x <- 0 until width) yield alive(x, y)
 
   def randomize(n: Int): Unit = {
     val r = Random
-    for (i <- 0 until n) {
+    for (i <- 0 until n)
       set(r.nextInt(width), r.nextInt(height))
-    }
   }
 
-  override def toString: String = cells map (line => ("" /: line)(_+_)) mkString "\n"
+  override def toString: String = cells map (line => ("" /: line)(_ + _)) mkString "\n"
 
 }
 
 object GameOfLife extends App {
 
   Scurses { screen =>
-
     val (w, h) = screen.size
-    val gol = GameOfLife(w / 2, h, wrapAround = true)
+    val gol    = GameOfLife(w / 2, h, wrapAround = true)
     gol.glider(4, 4)
     gol.glider(16, 6)
     gol.glider(28, 2)
     gol.randomize(w * h / 10)
 
     val palette = (34 until 39) ++ (39 until 219 by 36) ++ (219 until 214 by -1) ++ (214 until 24 by -36)
-    var step = 0
+    var step    = 0
 
     val timer = new Timer()
 
-    timer.scheduleAtFixedRate(new TimerTask {
-      override def run(): Unit = {
+    timer.scheduleAtFixedRate(
+      new TimerTask {
+        override def run(): Unit = {
           gol.step()
           for (x <- 0 until w / 2; y <- 0 until h) {
             val c = palette((step + x / 8 + y / 4) % palette.length)
@@ -100,8 +91,11 @@ object GameOfLife extends App {
           }
           step = (step + 1) % palette.length
           screen.refresh()
-      }
-    }, 33, 33)
+        }
+      },
+      33,
+      33
+    )
 
     screen.keypress()
     timer.cancel()

--- a/scurses/src/main/scala/net/team2xh/scurses/examples/HelloWorld.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/examples/HelloWorld.scala
@@ -1,14 +1,14 @@
 package net.team2xh.scurses.examples
 
-import net.team2xh.scurses.{Scurses, Colors}
+import net.team2xh.scurses.{Colors, Scurses}
 
 object HelloWorld extends App {
   Scurses { screen =>
-    val (w, h) = screen.size
+    val (w, h)   = screen.size
     val greeting = "Hello, world!"
-    val prompt = "Press a key to continue..."
-    screen.put(w/2 - greeting.length/2, h/2, greeting)
-    screen.put(w/2 - prompt.length/2, h/2 + 1, prompt, Colors.BRIGHT_BLACK)
+    val prompt   = "Press a key to continue..."
+    screen.put(w / 2 - greeting.length / 2, h / 2, greeting)
+    screen.put(w / 2 - prompt.length / 2, h / 2 + 1, prompt, Colors.BRIGHT_BLACK)
     screen.refresh()
     screen.keypress()
   }

--- a/scurses/src/main/scala/net/team2xh/scurses/examples/StressTest.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/examples/StressTest.scala
@@ -4,9 +4,8 @@ import net.team2xh.scurses.Scurses
 
 object StressTest extends App {
   Scurses { screen =>
-
     var running = true
-    val (w, h) = screen.size
+    val (w, h)  = screen.size
 
     val chars = ('#' to 'z').toArray
 
@@ -16,16 +15,15 @@ object StressTest extends App {
         var j = 0
         while (running) {
           val start = System.currentTimeMillis
-          for (x <- 0 until w; y <- 0 until h) {
+          for (x <- 0 until w; y <- 0 until h)
             if (x > 11 || y > 2) {
               val c = (x + y + j) % 256
-              screen.put(x, y, s"${chars((x + y + i) % chars.length)}", c, (c+128) % 256)
+              screen.put(x, y, s"${chars((x + y + i) % chars.length)}", c, (c + 128) % 256)
             }
-          }
-          i = (i+1) % chars.length
-          j = (j+1) % 256
+          i = (i + 1) % chars.length
+          j = (j + 1) % 256
           screen.refresh()
-          val fps = 1000.0 / (System.currentTimeMillis - start)
+          val fps  = 1000.0 / (System.currentTimeMillis - start)
           val _fps = "%2.2fFPS".format(fps)
           screen.put(0, 1, "           ")
           screen.put(2, 1, "%s%s".format(if (_fps.length < 8) " " * (8 - _fps.length) else "", _fps))


### PR DESCRIPTION
This PR adds and applies scalafmt which is the most used scala formatter around. It also adds a github workflow that checks the code is formatted when someone makes a PR (this check runs in parallel to the main build and also uses scalafmt-native which is ultra fast, typically it takes 1-5 seconds to run).

I have used `// format: off` and `// format: on` for code blocks where manual formatting was done for visual reasons (i.e. `BigText`). In general I tried to use a `.scalafmt.conf` that I think is the most visually appealing however I know this is down to personal preference so let me know if you want to change it.

I have also optimized imports as well as removing unnecessary ones. 