### PR TITLE
Make case class final plus remove var from fields

### DIFF
--- a/onions/src/main/scala/net/team2xh/onions/components/Frame.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/Frame.scala
@@ -7,9 +7,9 @@ import net.team2xh.scurses.{Keys, Scurses}
 
 import scala.language.implicitConversions
 
-case class Frame(title: Option[String] = None,
-                 var debug: Varying[Boolean] = false,
-                 var theme: Varying[ColorScheme] = Themes.default
+final case class Frame(title: Option[String] = None,
+                       debug: Varying[Boolean] = false,
+                       theme: Varying[ColorScheme] = Themes.default
 )(implicit screen: Scurses)
     extends Component(None) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/FramePanel.scala
@@ -30,7 +30,7 @@ object FramePanel {
   var idCounter = 0
 }
 
-case class FramePanel(parent: Component)(implicit screen: Scurses) extends Component(Some(parent)) {
+final case class FramePanel(parent: Component)(implicit screen: Scurses) extends Component(Some(parent)) {
 
   var width  = 0
   var height = 0

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/BarChart.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/BarChart.scala
@@ -21,14 +21,14 @@ import scala.Numeric.Implicits._
   * @param showValues Enables the display of the axis values
   * @param screen     Implicit Scurses screen
   */
-case class BarChart[T: Numeric](parent: FramePanel,
-                                values: Varying[Seq[T]],
-                                labels: Seq[String] = Seq(),
-                                min: Option[Int] = None,
-                                max: Option[Int] = None,
-                                palette: Seq[Int] = Palettes.default,
-                                showLabels: Boolean = true,
-                                showValues: Boolean = true
+final case class BarChart[T: Numeric](parent: FramePanel,
+                                      values: Varying[Seq[T]],
+                                      labels: Seq[String] = Seq(),
+                                      min: Option[Int] = None,
+                                      max: Option[Int] = None,
+                                      palette: Seq[Int] = Palettes.default,
+                                      showLabels: Boolean = true,
+                                      showValues: Boolean = true
 )(implicit screen: Scurses)
     extends Widget(parent, values) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/BigText.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/BigText.scala
@@ -5,7 +5,7 @@ import net.team2xh.onions.components.widgets.BigText.{empty, symbols}
 import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.Scurses
 
-case class BigText(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
+final case class BigText(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
     extends FontMapper(parent, empty, symbols, text, -1)
 
 object BigText {

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/CheckBox.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/CheckBox.scala
@@ -5,7 +5,7 @@ import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class CheckBox(parent: FramePanel, text: String, checked: Varying[Boolean] = false)(implicit screen: Scurses)
+final case class CheckBox(parent: FramePanel, text: String, checked: Varying[Boolean] = false)(implicit screen: Scurses)
     extends Widget(parent, checked) {
 
   def focusable = true

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/FontMapper.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/FontMapper.scala
@@ -9,7 +9,7 @@ abstract class FontMapper(parent: FramePanel,
                           empty: Seq[String],
                           symbols: Map[Char, Seq[String]],
                           text: Varying[String],
-                          var color: Varying[Int] = Colors.BRIGHT_WHITE
+                          val color: Varying[Int] = Colors.BRIGHT_WHITE
 )(implicit screen: Scurses)
     extends Widget(parent, text, color) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/HeatMap.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/HeatMap.scala
@@ -9,12 +9,12 @@ import net.team2xh.scurses.Scurses
 
 import scala.Numeric.Implicits._
 
-case class HeatMap[T: Numeric](parent: FramePanel,
-                               values: Varying[Seq[(T, T)]],
-                               labelX: String = "",
-                               labelY: String = "",
-                               radius: Varying[Int] = 5,
-                               showLabels: Boolean = false
+final case class HeatMap[T: Numeric](parent: FramePanel,
+                                     values: Varying[Seq[(T, T)]],
+                                     labelX: String = "",
+                                     labelY: String = "",
+                                     radius: Varying[Int] = 5,
+                                     showLabels: Boolean = false
 )(implicit screen: Scurses)
     extends Widget(parent, values, radius) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Histogram.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Histogram.scala
@@ -9,14 +9,14 @@ import net.team2xh.scurses.Scurses
 import java.text.DecimalFormat
 import scala.Numeric.Implicits._
 
-case class Histogram[T: Numeric](parent: FramePanel,
-                                 initialValues: Seq[T] = Seq[Double](),
-                                 palette: Seq[Int] = Palettes.rainbow,
-                                 min: Option[Int] = None,
-                                 max: Option[Int] = None,
-                                 labelY: String = "",
-                                 showLabels: Boolean = true,
-                                 showValues: Boolean = true
+final case class Histogram[T: Numeric](parent: FramePanel,
+                                       initialValues: Seq[T] = Seq[Double](),
+                                       palette: Seq[Int] = Palettes.rainbow,
+                                       min: Option[Int] = None,
+                                       max: Option[Int] = None,
+                                       labelY: String = "",
+                                       showLabels: Boolean = true,
+                                       showValues: Boolean = true
 )(implicit screen: Scurses)
     extends Widget(parent) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Input.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Input.scala
@@ -6,7 +6,7 @@ import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{Drawing, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class Input(parent: FramePanel, var defaultText: String = "Input")(implicit screen: Scurses)
+final case class Input(parent: FramePanel, defaultText: String = "Input")(implicit screen: Scurses)
     extends Widget(parent) {
 
   var text: Varying[String] = ""

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Label.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Label.scala
@@ -5,10 +5,10 @@ import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.{TextWrap, Varying}
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class Label(parent: FramePanel,
-                 text: Varying[String],
-                 alignment: Varying[Int] = TextWrap.ALIGN_LEFT,
-                 var action: () => Unit = () => {}
+final case class Label(parent: FramePanel,
+                       text: Varying[String],
+                       alignment: Varying[Int] = TextWrap.ALIGN_LEFT,
+                       action: () => Unit = () => {}
 )(implicit screen: Scurses)
     extends Widget(parent, text, alignment) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Radio.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Radio.scala
@@ -14,7 +14,7 @@ object Radio {
   }
 }
 
-private[widgets] case class Radio(parent: FramePanel, text: String, id: Int, choice: Varying[Int])(implicit
+private[widgets] final case class Radio(parent: FramePanel, text: String, id: Int, choice: Varying[Int])(implicit
     screen: Scurses
 ) extends Widget(parent) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/RichLabel.scala
@@ -6,7 +6,7 @@ import net.team2xh.onions.utils.{TextWrap, Varying}
 import net.team2xh.scurses.RichText.RichText
 import net.team2xh.scurses.Scurses
 
-case class RichLabel(parent: FramePanel, text: Varying[RichText])(implicit screen: Scurses)
+final case class RichLabel(parent: FramePanel, text: Varying[RichText])(implicit screen: Scurses)
     extends Widget(parent, text) {
 
   var lines = Seq[RichText]()

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/ScatterPlot.scala
@@ -9,12 +9,12 @@ import net.team2xh.scurses.Scurses
 import scala.Numeric.Implicits._
 import scala.collection.mutable
 
-case class ScatterPlot[T: Numeric](parent: FramePanel,
-                                   values: Varying[Seq[(T, T)]],
-                                   labelX: String = "",
-                                   labelY: String = "",
-                                   color: Int = 81,
-                                   showLabels: Boolean = true
+final case class ScatterPlot[T: Numeric](parent: FramePanel,
+                                         values: Varying[Seq[(T, T)]],
+                                         labelX: String = "",
+                                         labelY: String = "",
+                                         color: Int = 81,
+                                         showLabels: Boolean = true
 )(implicit screen: Scurses)
     extends Widget(parent, values) {
 

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/SevenSegment.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/SevenSegment.scala
@@ -5,7 +5,7 @@ import net.team2xh.onions.components.widgets.SevenSegment.{empty, symbols}
 import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.{Colors, Scurses}
 
-case class SevenSegment(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
+final case class SevenSegment(parent: FramePanel, text: Varying[String])(implicit screen: Scurses)
     extends FontMapper(parent, empty, symbols, text) {
 
   color := Colors.BRIGHT_GREEN

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Slider.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Slider.scala
@@ -6,8 +6,8 @@ import net.team2xh.onions.components.{FramePanel, Widget}
 import net.team2xh.onions.utils.Varying
 import net.team2xh.scurses.{Keys, Scurses}
 
-case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)(var currentValue: Varying[Int] = minValue)(implicit
-    screen: Scurses
+final case class Slider(parent: FramePanel, minValue: Int, maxValue: Int)(val currentValue: Varying[Int] = minValue)(
+    implicit screen: Scurses
 ) extends Widget(parent, minValue) {
 
   override def redraw(focus: Boolean, theme: ColorScheme): Unit = {

--- a/onions/src/main/scala/net/team2xh/onions/components/widgets/Spacer.scala
+++ b/onions/src/main/scala/net/team2xh/onions/components/widgets/Spacer.scala
@@ -3,4 +3,4 @@ package net.team2xh.onions.components.widgets
 import net.team2xh.onions.components.FramePanel
 import net.team2xh.scurses.Scurses
 
-case class Spacer(parent: FramePanel)(implicit screen: Scurses) extends Separator(parent, " ") {}
+final case class Spacer(parent: FramePanel)(implicit screen: Scurses) extends Separator(parent, " ") {}

--- a/onions/src/main/scala/net/team2xh/onions/utils/Math.scala
+++ b/onions/src/main/scala/net/team2xh/onions/utils/Math.scala
@@ -27,7 +27,7 @@ object Math {
   def simpleGauss2d(x: Double, y: Double, σ: Double): Double =
     math.exp(-(x * x / (2 * σ * σ) + y * y / (2 * σ * σ)))
 
-  case class GaussianArray(width: Int, height: Int, kernelRadius: Int = 1) {
+  final case class GaussianArray(width: Int, height: Int, kernelRadius: Int = 1) {
 
     val array = ArrayBuffer.fill[Double](width, height)(0.0)
 

--- a/scurses/src/main/scala/net/team2xh/scurses/RichText.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/RichText.scala
@@ -45,28 +45,28 @@ object RichText {
     }
   }
 
-  case class RichText(instructions: Instruction*)
+  final case class RichText(instructions: Instruction*)
 
   sealed trait Instruction
-  case class Text(text: String)                   extends Instruction
-  case class StartAttribute(attribute: Attribute) extends Instruction
-  case class StopAttribute(attribute: Attribute)  extends Instruction
-  case object ResetAttributes                     extends Instruction
+  final case class Text(text: String)                   extends Instruction
+  final case class StartAttribute(attribute: Attribute) extends Instruction
+  final case class StopAttribute(attribute: Attribute)  extends Instruction
+  case object ResetAttributes                           extends Instruction
 
   sealed trait Attribute
-  case object Bold                    extends Attribute
-  case object Underline               extends Attribute
-  case object Blink                   extends Attribute
-  case object Reverse                 extends Attribute
-  case object Foreground              extends Attribute
-  case object Background              extends Attribute
-  case class Foreground(color: Color) extends Attribute
-  case class Background(color: Color) extends Attribute
+  case object Bold                          extends Attribute
+  case object Underline                     extends Attribute
+  case object Blink                         extends Attribute
+  case object Reverse                       extends Attribute
+  case object Foreground                    extends Attribute
+  case object Background                    extends Attribute
+  final case class Foreground(color: Color) extends Attribute
+  final case class Background(color: Color) extends Attribute
 
   sealed trait Color
-  case class NamedColor(name: String) extends Color
-  case class IndexedColor(code: Int)  extends Color
-  case class HexColor(hex: String)    extends Color
+  final case class NamedColor(name: String) extends Color
+  final case class IndexedColor(code: Int)  extends Color
+  final case class HexColor(hex: String)    extends Color
 
   private def letter[_: P]   = P(CharIn("a-z"))
   private def digit[_: P]    = P(CharIn("0-9"))

--- a/scurses/src/main/scala/net/team2xh/scurses/examples/GameOfLife.scala
+++ b/scurses/src/main/scala/net/team2xh/scurses/examples/GameOfLife.scala
@@ -5,9 +5,9 @@ import net.team2xh.scurses.Scurses
 import java.util.{Timer, TimerTask}
 import scala.util.Random
 
-case class GameOfLife(width: Int, height: Int, wrapAround: Boolean = false) {
+final case class GameOfLife(width: Int, height: Int, wrapAround: Boolean = false) {
 
-  var cells = for (y <- 0 until height) yield for (x <- 0 until width) yield 0
+  var cells = for (_ <- 0 until height) yield for (_ <- 0 until width) yield 0
 
   def field = cells
 


### PR DESCRIPTION
In summary this PR modifies `case class`es so they are more idiomatic to how they are meant to be used in Scala, this is done in the following ways

1. `case class`es are made final (this should honestly be the default in Scala). The reason why `case class`es should be final is that a lot of the features that Scala brings to the table when using `case class` (such as destructuring) relies on the generated methods not being overridden (specifically `equals`/`hashCode`). If a `case class` is not final, a user can theoritically subclass a `case class`, override something like `equals`, feed that subclasses `case class` into your code and then suddenly things break. If you need to do these things you should be using a normal `class` (of which there is no problem)
2. `var` fields in a `case class` have been changed to `val`. Again certain assumptions about using `case class` break if the constructor fields can randomly be mutated without creating an extra copy of `case class`. Thankfully none of the code actually broke when I change it from `var` to `val` so this may have been a relic from earlier code when `Varying` was introduced.